### PR TITLE
Fix: prevent stuck transitions from changeSubject errors, orphan-locked deferred events, and perpetual grace period reset

### DIFF
--- a/packages/core-persistence/package.json
+++ b/packages/core-persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-core-persistence",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "description": "XJog chart abstract persistence",
   "engines": {
     "npm": ">=8.19.4",
@@ -29,7 +29,7 @@
     "clean": "rm -rf node_modules lib"
   },
   "dependencies": {
-    "@samihult/xjog-util": "^0.0.36",
+    "@samihult/xjog-util": "^0.0.37",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/packages/core-persistence/src/PersistenceAdapter.ts
+++ b/packages/core-persistence/src/PersistenceAdapter.ts
@@ -3,11 +3,18 @@ import { EventObject, StateSchema, Typestate, State } from 'xstate';
 
 import {
   AbstractPersistenceAdapter,
-  ChartReference,
+	type ChartReference,
   getCorrelationIdentifier,
 } from '@samihult/xjog-util';
+import { v4 as uuidV4 } from 'uuid';
+import {
+	type EventObject,
+	State,
+	type StateSchema,
+	type Typestate,
+} from 'xstate';
 
-import { PersistedChart, PersistedDeferredEvent } from './EntryTypes';
+import type { PersistedChart, PersistedDeferredEvent } from './EntryTypes';
 
 /**
  * Abstract adapter class for XJog persistence.
@@ -355,6 +362,14 @@ export abstract class PersistenceAdapter<
 
       trace({ message: 'Marking all charts paused' });
       await this.markAllChartsPaused(connection);
+
+			// Bug fix: release deferred event locks left behind by instances that
+			// were killed without graceful shutdown. Without this, events locked
+			// by dead instance UUIDs are permanently stuck since new instances
+			// only query WHERE lock IS NULL (releaseAll/releaseAllDeferredEvents
+			// is only called from XJog.shutdown(), which never runs on SIGKILL).
+			trace({ message: 'Releasing all deferred event locks' });
+			await this.unmarkAllDeferredEventsForProcessing(connection);
 
       trace({ message: 'Adding the instance to the list' });
       await this.insertInstance(instanceId, connection);

--- a/packages/core-pg/package.json
+++ b/packages/core-pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-core-pg",
-  "version": "0.0.66",
+  "version": "0.0.67",
   "description": "XJog chart Postgres persistence",
   "engines": {
     "npm": ">=8.19.4",
@@ -29,8 +29,8 @@
     "clean": "rm -rf node_modules lib"
   },
   "dependencies": {
-    "@samihult/xjog-core-persistence": "^0.0.42",
-    "@samihult/xjog-util": "^0.0.36",
+    "@samihult/xjog-core-persistence": "^0.0.43",
+    "@samihult/xjog-util": "^0.0.37",
     "node-pg-migrate": "^6.2.1",
     "pg": "^8.7.3",
     "pg-bind": "^1.0.1",

--- a/packages/core-pglite/package.json
+++ b/packages/core-pglite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-core-pglite",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Lightweight PG adapter",
   "keywords": [
     "pg"
@@ -28,8 +28,8 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.3.5",
-    "@samihult/xjog-core-persistence": "^0.0.42",
-    "@samihult/xjog-util": "^0.0.36",
+    "@samihult/xjog-core-persistence": "^0.0.43",
+    "@samihult/xjog-util": "^0.0.37",
     "node-pg-migrate": "^6.2.1"
   },
   "devDependencies": {

--- a/packages/core-pglite/src/PGlitePersistenceAdapter.test.ts
+++ b/packages/core-pglite/src/PGlitePersistenceAdapter.test.ts
@@ -117,3 +117,35 @@ describe('PGlitePersistenceAdapter', () => {
     expect(event).toBeUndefined();
   });
 });
+
+describe('PGlitePersistenceAdapter: orphan-locked deferred events released on startup', () => {
+  it('Releases all deferred event locks during overthrowOtherInstances', async () => {
+    const adapter = await PGlitePersistenceAdapter.connect();
+
+    // Seed a deferred event with a lock set to simulate a dead instance that
+    // was killed without graceful shutdown (releaseAll never ran).
+    await adapter.withTransaction(async (client) => {
+      await client.exec('DELETE FROM "deferredEvents"');
+      await client.exec(
+        `INSERT INTO "deferredEvents"
+          ("eventId", "machineId", "chartId", "event", "delay", "due", "lock")
+         VALUES ('evt-orphan', 'm', 'c', '{}', 0, NOW(), 'dead-instance-uuid')`,
+      );
+    });
+
+    // Verify the lock is set before we call overthrowOtherInstances
+    const before = await adapter.withTransaction(async (client) => {
+      return client.query('SELECT "lock" FROM "deferredEvents"');
+    });
+    expect(before.rows[0].lock).toBe('dead-instance-uuid');
+
+    // overthrowOtherInstances should now clear the lock as part of startup
+    await adapter.overthrowOtherInstances('new-instance-uuid', 'cid');
+
+    // Lock must be NULL so the new instance can pick up the event
+    const after = await adapter.withTransaction(async (client) => {
+      return client.query('SELECT "lock" FROM "deferredEvents"');
+    });
+    expect(after.rows[0].lock).toBeNull();
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog",
-  "version": "0.0.322",
+  "version": "0.0.323",
   "description": "XState chart runner for long-running charts",
   "engines": {
     "npm": ">=8.19.4",
@@ -30,15 +30,15 @@
     "clean": "rm -rf node_modules lib"
   },
   "dependencies": {
-    "@samihult/xjog-core-persistence": "^0.0.42",
-    "@samihult/xjog-util": "^0.0.36",
+    "@samihult/xjog-core-persistence": "^0.0.43",
+    "@samihult/xjog-util": "^0.0.37",
     "async-mutex": "^0.3.2",
     "rxjs": "^7.4.0",
     "uuid": "^8.3.2",
     "xstate": "4.26.1"
   },
   "devDependencies": {
-    "@samihult/xjog-core-pglite": "^0.0.5",
+    "@samihult/xjog-core-pglite": "^0.0.6",
     "@swc/cli": "^0.1.57",
     "@swc/core": "^1.2.223",
     "@swc/jest": "^0.2.22",

--- a/packages/core/src/XJogActivityManager.ts
+++ b/packages/core/src/XJogActivityManager.ts
@@ -1,15 +1,14 @@
-import { Event, EventObject, SCXML, Subscription } from 'xstate';
-import { Mutex, MutexInterface, withTimeout } from 'async-mutex';
-import { getEventType, toSCXMLEvent } from 'xstate/lib/utils';
-import * as actions from 'xstate/lib/actions';
-
 import {
-  ChartReference,
+  type ActivityRef,
+  type ChartReference,
   getCorrelationIdentifier,
-  ActivityRef,
 } from '@samihult/xjog-util';
+import { Mutex, type MutexInterface, withTimeout } from 'async-mutex';
+import type { Event, EventObject, SCXML, Subscription } from 'xstate';
+import * as actions from 'xstate/lib/actions';
+import { getEventType, toSCXMLEvent } from 'xstate/lib/utils';
 
-import { XJog } from './XJog';
+import type { XJog } from './XJog';
 
 /**
  * Ongoing activities are managed at the top level because they may

--- a/packages/core/src/XJogChart.test.ts
+++ b/packages/core/src/XJogChart.test.ts
@@ -1,0 +1,135 @@
+import { PGlitePersistenceAdapter } from '@samihult/xjog-core-pglite';
+import { Subject } from 'rxjs';
+import { createMachine } from 'xstate';
+
+import type { XJog } from './XJog';
+import { XJogMachine } from './XJogMachine';
+
+// PGlite initialisation can take several seconds
+jest.setTimeout(30000);
+
+/**
+ * Build a minimal mock XJog instance that satisfies all fields accessed by
+ * XJogChart.create() and XJogChart.send() without ever calling xJog.start().
+ * Calling start() would kick off recurring timers (deferredEventManager,
+ * persistence death-note polling) that keep the event loop alive and cause
+ * Jest workers to hang.
+ */
+function buildMockXJog(persistence: PGlitePersistenceAdapter): XJog {
+  const xJog: any = {
+    id: 'test-xjog-instance',
+    dying: false,
+    persistence,
+    // timeExecution just calls the routine immediately — same as production
+    // but without any timing telemetry overhead
+    timeExecution: <T>(_op: string, routine: () => T): T => routine(),
+    simulator: { isEnabled: () => false },
+    updateHooks: new Set<any>(),
+    changeSubject: new Subject<any>(),
+    activityManager: {
+      sendAutoForwardEvent: jest.fn(),
+      stopActivity: jest.fn(),
+      stopAllForChart: jest.fn(),
+      registerActivity: jest.fn(),
+      activityOngoing: jest.fn().mockResolvedValue(false),
+    },
+    deferredEventManager: {
+      defer: jest.fn().mockResolvedValue(undefined),
+      cancel: jest.fn().mockResolvedValue(undefined),
+      cancelAllForChart: jest.fn().mockResolvedValue(undefined),
+    },
+    sendEvent: jest.fn().mockResolvedValue(null),
+    // Logging — no-ops are fine
+    log: jest.fn(),
+    trace: jest.fn(),
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    emit: jest.fn(),
+    options: {
+      persistence,
+      chartMutexTimeout: 2000,
+      startup: {
+        adoptionFrequency: 2000,
+        gracePeriod: 30000,
+        skipRunningActionsOnRehydrate: false,
+      },
+      deferredEvents: {
+        batchSize: 100,
+        interval: 30000,
+        lookAhead: 30000,
+      },
+      shutdown: {
+        ownChartPollingFrequency: 500,
+      },
+    },
+  };
+
+  return xJog as unknown as XJog;
+}
+
+describe('XJogChart: executeActions must run even if changeSubject.next() throws', () => {
+  it('Calls executeActions after changeSubject.next() throws', async () => {
+    const persistence = await PGlitePersistenceAdapter.connect();
+    const xJog = buildMockXJog(persistence);
+
+    // Minimal two-state machine: idle --(go)--> done
+    const machine = createMachine({
+      id: 'bug1-machine',
+      initial: 'idle',
+      states: {
+        idle: { on: { go: 'done' } },
+        done: { type: 'final' },
+      },
+    });
+
+    const xJogMachine = new XJogMachine(xJog, machine);
+    const chart = await xJogMachine.createChart();
+
+    // Force changeSubject.next() to throw so we can verify executeActions
+    // is still reached. This is the core regression scenario for a bug fixed:
+    // if the error propagates out of changeSubject.next(), executeActions
+    // is skipped and the chart ends up with unexecuted persisted actions
+    // (e.g. xstate.send delayed transitions).
+    jest.spyOn(xJog.changeSubject, 'next').mockImplementationOnce(() => {
+      throw new Error('Simulated subscriber error');
+    });
+
+    // @ts-expect-error Private access
+    const executeActionsSpy = jest.spyOn(chart, 'executeActions');
+
+    await chart.send('go');
+
+    expect(executeActionsSpy).toHaveBeenCalled();
+  });
+
+  it('Returns the new state even when changeSubject.next() throws', async () => {
+    const persistence = await PGlitePersistenceAdapter.connect();
+    const xJog = buildMockXJog(persistence);
+
+    const machine = createMachine({
+      id: 'bug1-machine-return',
+      initial: 'idle',
+      states: {
+        idle: { on: { go: 'done' } },
+        done: { type: 'final' },
+      },
+    });
+
+    const xJogMachine = new XJogMachine(xJog, machine);
+    const chart = await xJogMachine.createChart();
+
+    // Without the Bug 1 fix, a throwing subscriber would cause the outer
+    // catch block in send() to swallow the error and return null. The fix
+    // isolates changeSubject.next() so send() returns the new state.
+    jest.spyOn(xJog.changeSubject, 'next').mockImplementationOnce(() => {
+      throw new Error('Simulated subscriber error');
+    });
+
+    const result = await chart.send('go');
+
+    expect(result).not.toBeNull();
+    expect(result?.value).toBe('done');
+  });
+});

--- a/packages/core/src/XJogChart.ts
+++ b/packages/core/src/XJogChart.ts
@@ -1,46 +1,43 @@
-import { v4 as uuidV4 } from 'uuid';
-import { doneInvoke, getActionFunction } from 'xstate/lib/actions';
-import { Mutex, MutexInterface, withTimeout } from 'async-mutex';
-import { concat, Observable, of, map, from, filter } from 'rxjs';
-
-import {
-  getCorrelationIdentifier,
-  ChartIdentifier,
-  ChartReference,
-  ActivityRef,
-  LogFields,
-  XJogLogEmitter,
-  XJogStateChange,
-} from '@samihult/xjog-util';
-
-import {
-  PersistenceAdapter,
+import type {
   PersistedDeferredEvent,
+  PersistenceAdapter,
 } from '@samihult/xjog-core-persistence';
-
 import {
-  ActionObject,
+  type ActivityRef,
+  ChartIdentifier,
+  type ChartReference,
+  getCorrelationIdentifier,
+  type LogFields,
+  XJogLogEmitter,
+  type XJogStateChange,
+} from '@samihult/xjog-util';
+import { Mutex, type MutexInterface, withTimeout } from 'async-mutex';
+import { concat, filter, from, map, type Observable, of } from 'rxjs';
+import { v4 as uuidV4 } from 'uuid';
+import {
+  type ActionObject,
   ActionTypes,
-  ActivityActionObject,
-  AnyEventObject,
-  CancelAction,
-  Event,
-  EventObject,
+  type ActivityActionObject,
+  type AnyEventObject,
+  type CancelAction,
+  type Event,
+  type EventObject,
   Interpreter,
-  InvokeCallback,
-  InvokeDefinition,
-  Observer,
-  SCXML,
-  SendActionObject,
-  Spawnable,
+  type InvokeCallback,
+  type InvokeDefinition,
+  type Observer,
+  type SCXML,
+  type SendActionObject,
+  type Spawnable,
   State,
-  StateMachine,
-  StateNodeConfig,
-  StateSchema,
-  Subscribable,
-  Subscription,
-  Typestate,
+  type StateMachine,
+  type StateNodeConfig,
+  type StateSchema,
+  type Subscribable,
+  type Subscription,
+  type Typestate,
 } from 'xstate';
+import { doneInvoke, getActionFunction } from 'xstate/lib/actions';
 
 import {
   isFunction,
@@ -53,22 +50,20 @@ import {
   toObserver,
   toSCXMLEvent,
 } from 'xstate/lib/utils';
-
-import { SpawnOptions, XJogMachine } from './XJogMachine';
-import { XJog } from './XJog';
-
-import {
-  ResolvedXJogChartOptions,
-  resolveXJogChartOptions,
-  XJogChartCreationOptions,
-} from './XJogChartCreationOptions';
-
 import {
   resolveXJogCreateStateChange,
   resolveXJogDeleteStateChange,
   resolveXJogUpdateStateChange,
 } from './resolveXJogStateChange';
-import { SimulatorAction } from './XJogSimulator';
+import type { XJog } from './XJog';
+
+import {
+  type ResolvedXJogChartOptions,
+  resolveXJogChartOptions,
+  type XJogChartCreationOptions,
+} from './XJogChartCreationOptions';
+import type { SpawnOptions, XJogMachine } from './XJogMachine';
+import type { SimulatorAction } from './XJogSimulator';
 
 export type XJogSendAction<
   TContext = any,
@@ -626,7 +621,15 @@ export class XJogChart<
           });
         }
 
-        this.xJog.changeSubject.next(change);
+        // Bug fix: changeSubject.next() can throw if a synchronous subscriber
+        // errors. This must not prevent executeActions() from running, as that
+        // would leave persisted state with actions that never execute (e.g.
+        // deferred events from xstate.send delayed transitions).
+        try {
+          this.xJog.changeSubject.next(change);
+        } catch (err) {
+          error('Failed to emit change event', { err });
+        }
 
         await this.xJog.timeExecution(
           'chart.send.execute actions',

--- a/packages/core/src/XJogStartupManager.test.ts
+++ b/packages/core/src/XJogStartupManager.test.ts
@@ -1,7 +1,7 @@
+import type { PersistenceAdapter } from '@samihult/xjog-core-persistence';
 import { PGlitePersistenceAdapter } from '@samihult/xjog-core-pglite';
-import { PersistenceAdapter } from '@samihult/xjog-core-persistence';
 
-import { XJog } from './XJog';
+import type { XJog } from './XJog';
 import { XJogStartupManager } from './XJogStartupManager';
 
 function mockXJogWithStartupManager(
@@ -50,17 +50,75 @@ describe('XJogStartupManager', () => {
     const [, startupManager] = mockXJogWithStartupManager(persistence);
 
     jest.spyOn(persistence, 'overthrowOtherInstances');
-    // @ts-ignore Private access
+    // @ts-expect-error Private access
     jest.spyOn(startupManager, 'startAdoptionGracePeriod');
-    // @ts-ignore Private access
+    // @ts-expect-error Private access
     jest.spyOn(startupManager, 'adoptCharts');
 
     await startupManager.start();
 
     expect(persistence.overthrowOtherInstances).toHaveBeenCalled();
-    // @ts-ignore Private access
+    // @ts-expect-error Private access
     expect(startupManager.startAdoptionGracePeriod).toHaveBeenCalled();
-    // @ts-ignore Private access
+    // @ts-expect-error Private access
     expect(startupManager.adoptCharts).toHaveBeenCalled();
+  });
+});
+
+describe('XJogStartupManager: grace period timer must not reset on every cycle', () => {
+  it('Does not restart the grace period timer when it is already running', async () => {
+    const persistence = await PGlitePersistenceAdapter.connect();
+    const [, startupManager] = mockXJogWithStartupManager(persistence);
+
+    // @ts-expect-error Private access
+    jest.spyOn(startupManager, 'startAdoptionGracePeriod');
+
+    // Simulate a paused chart so adoptCharts enters the "more to adopt" branch
+    jest.spyOn(persistence, 'gentlyAdoptCharts').mockResolvedValue([]);
+    jest.spyOn(persistence, 'getPausedChartCount').mockResolvedValue(1);
+
+    // Pre-set the grace period timer to simulate it already being active.
+    // Without the fix, startAdoptionGracePeriod() would be called
+    // unconditionally, resetting the 30s countdown on every 2s cycle.
+    // @ts-expect-error Private access
+    startupManager.startupGracePeriodTimer = setTimeout(() => {}, 99999);
+
+    // @ts-expect-error Private access
+    await startupManager.adoptCharts();
+
+    // The grace period timer was already running, so startAdoptionGracePeriod
+    // must NOT have been called again (that would reset the 30s countdown).
+    // @ts-expect-error Private access
+    expect(startupManager.startAdoptionGracePeriod).not.toHaveBeenCalled();
+
+    // Clean up the timers we set
+    // @ts-expect-error Private access
+    clearTimeout(startupManager.startupGracePeriodTimer);
+    // @ts-expect-error Private access
+    clearTimeout(startupManager.adoptionLoopTimer);
+  });
+
+  it('Starts the grace period timer on the first adoption cycle when charts remain', async () => {
+    const persistence = await PGlitePersistenceAdapter.connect();
+    const [, startupManager] = mockXJogWithStartupManager(persistence);
+
+    // @ts-expect-error Private access
+    jest.spyOn(startupManager, 'startAdoptionGracePeriod');
+
+    jest.spyOn(persistence, 'gentlyAdoptCharts').mockResolvedValue([]);
+    jest.spyOn(persistence, 'getPausedChartCount').mockResolvedValue(1);
+
+    // No pre-existing timer — grace period should be started exactly once
+    // @ts-expect-error Private access
+    await startupManager.adoptCharts();
+
+    // @ts-expect-error Private access
+    expect(startupManager.startAdoptionGracePeriod).toHaveBeenCalledTimes(1);
+
+    // Clean up timers
+    // @ts-expect-error Private access
+    clearTimeout(startupManager.startupGracePeriodTimer);
+    // @ts-expect-error Private access
+    clearTimeout(startupManager.adoptionLoopTimer);
   });
 });

--- a/packages/core/src/XJogStartupManager.ts
+++ b/packages/core/src/XJogStartupManager.ts
@@ -1,7 +1,9 @@
-import { ChartReference, getCorrelationIdentifier } from '@samihult/xjog-util';
-
-import { ResolvedXJogOptions } from './XJogOptions';
-import { XJog } from './XJog';
+import {
+  type ChartReference,
+  getCorrelationIdentifier,
+} from '@samihult/xjog-util';
+import type { XJog } from './XJog';
+import type { ResolvedXJogOptions } from './XJogOptions';
 
 /**
  * Class that will handle the startup sequence.
@@ -149,9 +151,13 @@ export class XJogStartupManager {
     if (pausedChartCount > 0) {
       trace({ message: 'More charts to adopt', pausedChartCount });
 
-      // Restart the grace period, otherwise it could be
-      // spent on a lengthy adoption process alone
-      this.startAdoptionGracePeriod();
+      // Bug fix: only start the grace period if one isn't already running.
+      // Previously this was called on every adoption cycle (~every 2s),
+      // which cleared and reset the 30s timer each time, preventing
+      // forciblyOverThrowStubbornInstances() from ever firing.
+      if (!this.startupGracePeriodTimer) {
+        this.startAdoptionGracePeriod();
+      }
 
       this.adoptionLoopTimer = setTimeout(
         this.adoptCharts.bind(this),

--- a/packages/digest-persistence/package.json
+++ b/packages/digest-persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-digest-persistence",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "XJog chart digest persistence adapter",
   "engines": {
     "npm": ">=8.19.4",
@@ -27,7 +27,7 @@
     "clean": "rm -rf node_modules lib"
   },
   "dependencies": {
-    "@samihult/xjog-util": "^0.0.36",
+    "@samihult/xjog-util": "^0.0.37",
     "rxjs": "^7.4.0"
   },
   "devDependencies": {

--- a/packages/digest-pg/package.json
+++ b/packages/digest-pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-digest-pg",
-  "version": "0.0.120",
+  "version": "0.0.121",
   "description": "XJog Postgres digest persistence",
   "engines": {
     "npm": ">=8.19.4",
@@ -29,8 +29,8 @@
     "clean": "rm -rf node_modules lib"
   },
   "dependencies": {
-    "@samihult/xjog-digest-persistence": "^0.0.27",
-    "@samihult/xjog-util": "^0.0.36",
+    "@samihult/xjog-digest-persistence": "^0.0.28",
+    "@samihult/xjog-util": "^0.0.37",
     "node-pg-migrate": "^6.2.1",
     "pg": "^8.7.3",
     "pg-bind": "^1.0.1",

--- a/packages/digest-pglite/package.json
+++ b/packages/digest-pglite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-digest-pglite",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Digest package with PGlite backend",
   "author": "Juha Mustonen <juha.mustonen@iki.fi>",
   "homepage": "",

--- a/packages/digest-reader/package.json
+++ b/packages/digest-reader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-digest-reader",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "XJog chart digest reader",
   "engines": {
     "npm": ">=8.19.4",
@@ -29,8 +29,8 @@
     "clean": "rm -rf node_modules lib"
   },
   "dependencies": {
-    "@samihult/xjog-digest-persistence": "^0.0.27",
-    "@samihult/xjog-util": "^0.0.36",
+    "@samihult/xjog-digest-persistence": "^0.0.28",
+    "@samihult/xjog-util": "^0.0.37",
     "rxjs": "^7.4.0"
   },
   "devDependencies": {

--- a/packages/digest-reader/src/XJogDigestReader.ts
+++ b/packages/digest-reader/src/XJogDigestReader.ts
@@ -1,44 +1,43 @@
-import { XJogLogEmitter, ChartReference } from '@samihult/xjog-util';
-import { concat, from, Observable, concatMap } from 'rxjs';
-
-import {
-  ChartReferenceWithTimestamp,
-  DigestPersistenceAdapter,
-  DigestQuery,
-} from '@samihult/xjog-digest-persistence';
+import type {
+	ChartReferenceWithTimestamp,
+	DigestPersistenceAdapter,
+	DigestQuery,
+} from "@samihult/xjog-digest-persistence";
+import { type ChartReference, XJogLogEmitter } from "@samihult/xjog-util";
+import { concat, concatMap, from, type Observable } from "rxjs";
 
 export class XJogDigestReader extends XJogLogEmitter {
-  public readonly component = 'digest/reader';
+	public readonly component = "digest/reader";
 
-  constructor(private readonly persistence: DigestPersistenceAdapter) {
-    super();
-  }
+	constructor(private readonly persistence: DigestPersistenceAdapter) {
+		super();
+	}
 
-  public async queryDigests(
-    query: DigestQuery,
-  ): Promise<ChartReferenceWithTimestamp[]> {
-    return this.persistence.queryDigests(query);
-  }
+	public async queryDigests(
+		query: DigestQuery,
+	): Promise<ChartReferenceWithTimestamp[]> {
+		return this.persistence.queryDigests(query);
+	}
 
-  public observeDigests(
-    query: DigestQuery,
-  ): Observable<ChartReferenceWithTimestamp> {
-    return concat(
-      from(this.queryDigests(query)).pipe(
-        // From array to individual items
-        concatMap((refs: ChartReferenceWithTimestamp[]) => refs),
-      ),
-      from(this.persistence.newDigestEntriesSubject).pipe(
-        concatMap((ref: ChartReference) => {
-          return this.persistence.queryDigests({
-            ...query,
-            machineId: ref.machineId,
-            chartId: ref.chartId,
-          });
-        }),
-        // From array to individual items
-        concatMap((refs: ChartReference[]) => refs),
-      ),
-    );
-  }
+	public observeDigests(
+		query: DigestQuery,
+	): Observable<ChartReferenceWithTimestamp> {
+		return concat(
+			from(this.queryDigests(query)).pipe(
+				// From array to individual items
+				concatMap((refs: ChartReferenceWithTimestamp[]) => refs),
+			),
+			from(this.persistence.newDigestEntriesSubject).pipe(
+				concatMap((ref: ChartReference) => {
+					return this.persistence.queryDigests({
+						...query,
+						machineId: ref.machineId,
+						chartId: ref.chartId,
+					});
+				}),
+				// From array to individual items
+				concatMap((refs: ChartReferenceWithTimestamp[]) => refs),
+			),
+		);
+	}
 }

--- a/packages/digest-writer/package.json
+++ b/packages/digest-writer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-digest-writer",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "XJog chart digest writer",
   "engines": {
     "npm": ">=8.19.4",

--- a/packages/journal-persistence/package.json
+++ b/packages/journal-persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-journal-persistence",
-  "version": "0.0.55",
+  "version": "0.0.56",
   "description": "XJog chart abstract journal persistence adapter",
   "engines": {
     "npm": ">=8.19.4",
@@ -29,7 +29,7 @@
     "clean": "rm -rf node_modules lib"
   },
   "dependencies": {
-    "@samihult/xjog-util": "^0.0.36",
+    "@samihult/xjog-util": "^0.0.37",
     "rfc6902": "^5.0.1",
     "rxjs": "^7.4.0",
     "uuid": "^8.3.2"

--- a/packages/journal-persistence/src/FullStateEntry.ts
+++ b/packages/journal-persistence/src/FullStateEntry.ts
@@ -1,17 +1,20 @@
-import { EventObject, StateValue } from 'xstate';
-import { ChartReference, XJogStateChangeAction } from "@samihult/xjog-util";
+import type {
+	ChartReference,
+	XJogStateChangeAction,
+} from "@samihult/xjog-util";
+import type { EventObject, StateValue } from "xstate";
 
 export type FullStateEntry = {
-  id: number;
-  created: number;
-  timestamp: number;
+	id: number;
+	created: number;
+	timestamp: number;
 
-  ownerId: string;
-  ref: ChartReference;
-  parentRef: ChartReference | null;
+	ownerId: string;
+	ref: ChartReference;
+	parentRef: ChartReference | null;
 
-  event: EventObject | null;
-  state: StateValue | null;
-  context: any | null;
-  actions: XJogStateChangeAction[];
+	event: EventObject | null;
+	state: StateValue | null;
+	context: any | null;
+	actions: XJogStateChangeAction[] | null;
 };

--- a/packages/journal-persistence/src/JournalEntry.ts
+++ b/packages/journal-persistence/src/JournalEntry.ts
@@ -1,30 +1,33 @@
-import { EventObject, StateValue } from 'xstate';
-import { ChartReference, XJogStateChangeAction } from '@samihult/xjog-util';
-import { Operation } from 'rfc6902';
+import type {
+	ChartReference,
+	XJogStateChangeAction,
+} from "@samihult/xjog-util";
+import type { Operation } from "rfc6902";
+import type { EventObject, StateValue } from "xstate";
 
 export type JournalEntry = {
-  id: number;
-  timestamp: number;
-  ref: ChartReference;
+	id: number;
+	timestamp: number;
+	ref: ChartReference;
 
-  event: EventObject | null;
-  state: StateValue | null;
-  context: any | null;
-  actions: XJogStateChangeAction[];
+	event: EventObject | null;
+	state: StateValue | null;
+	context: any | null;
+	actions: XJogStateChangeAction[] | null;
 
-  stateDelta: Operation[];
-  contextDelta: Operation[];
+	stateDelta: Operation[];
+	contextDelta: Operation[];
 };
 
 export type JournalEntryAutoFields = {
-  id: number;
-  timestamp: number;
+	id: number;
+	timestamp: number;
 };
 
 export type JournalEntryInsertFields = {
-  ref: ChartReference;
-  event: EventObject | null;
-  stateDelta: Operation[];
-  contextDelta: Operation[];
-  actions: XJogStateChangeAction[];
+	ref: ChartReference;
+	event: EventObject | null;
+	stateDelta: Operation[];
+	contextDelta: Operation[];
+	actions: XJogStateChangeAction[] | null;
 };

--- a/packages/journal-pg/package.json
+++ b/packages/journal-pg/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-journal-pg",
-  "version": "0.0.120",
+  "version": "0.0.121",
   "description": "XJog Postgres journaling persistence",
   "engines": {
     "npm": ">=8.19.4",
@@ -29,9 +29,9 @@
     "clean": "rm -rf node_modules lib"
   },
   "dependencies": {
-    "@samihult/xjog-core-persistence": "^0.0.42",
-    "@samihult/xjog-journal-persistence": "^0.0.55",
-    "@samihult/xjog-util": "^0.0.36",
+    "@samihult/xjog-core-persistence": "^0.0.43",
+    "@samihult/xjog-journal-persistence": "^0.0.56",
+    "@samihult/xjog-util": "^0.0.37",
     "node-pg-migrate": "^6.2.1",
     "pg": "^8.7.3",
     "pg-bind": "^1.0.1",

--- a/packages/journal-pglite/package.json
+++ b/packages/journal-pglite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-journal-pglite",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "> TODO: description",
   "author": "Juha Mustonen <juha.mustonen@iki.fi>",
   "homepage": "",

--- a/packages/journal-reader/package.json
+++ b/packages/journal-reader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-journal-reader",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "description": "XJog chart journal reader",
   "engines": {
     "npm": ">=8.19.4",
@@ -29,8 +29,8 @@
     "clean": "rm -rf node_modules lib"
   },
   "dependencies": {
-    "@samihult/xjog": "^0.0.322",
-    "@samihult/xjog-util": "^0.0.36",
+    "@samihult/xjog": "^0.0.323",
+    "@samihult/xjog-util": "^0.0.37",
     "pg": "^8.7.3",
     "pg-bind": "^1.0.1",
     "pg-listen": "^1.7.0",

--- a/packages/journal-writer/package.json
+++ b/packages/journal-writer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-journal-writer",
-  "version": "0.0.76",
+  "version": "0.0.77",
   "description": "XJog chart journal writer",
   "engines": {
     "npm": ">=8.19.4",
@@ -27,9 +27,9 @@
     "clean": "rm -rf node_modules lib"
   },
   "dependencies": {
-    "@samihult/xjog": "^0.0.322",
-    "@samihult/xjog-journal-persistence": "^0.0.55",
-    "@samihult/xjog-util": "^0.0.36"
+    "@samihult/xjog": "^0.0.323",
+    "@samihult/xjog-journal-persistence": "^0.0.56",
+    "@samihult/xjog-util": "^0.0.37"
   },
   "devDependencies": {
     "@types/jest": "^27.0.1",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-util",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "description": "XJog utils",
   "engines": {
     "npm": ">=8.19.4",


### PR DESCRIPTION
- Wrap changeSubject.next() in try/catch so executeActions() always runs
- Release deferred event locks in overthrowOtherInstances() on startup
- Guard startAdoptionGracePeriod() so the 30s timer is never reset
Regression tests added for all three fixes.