### PR TITLE
Fix rxjs dependency resolution and add missing journal-persistence dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "watch-all": "lerna run build ; lerna watch -- lerna run build --since"
   },
   "devDependencies": {
-    "lerna": "7.4.2"
+    "lerna": "7.4.2",
+    "rxjs": "^7.8.2"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,6 @@
     "@samihult/xjog-core-persistence": "^0.0.43",
     "@samihult/xjog-util": "^0.0.37",
     "async-mutex": "^0.3.2",
-    "rxjs": "^7.4.0",
     "uuid": "^8.3.2",
     "xstate": "4.26.1"
   },
@@ -49,7 +48,6 @@
     "@types/uuid": "^8.3.1",
     "@typescript-eslint/eslint-plugin": "^5.40.0",
     "@typescript-eslint/parser": "^5.40.0",
-    "concurrently": "^6.2.1",
     "cpx-fixed": "^1.6.0",
     "eslint": "^8.25.0",
     "eslint-config-prettier": "^8.5.0",
@@ -64,5 +62,8 @@
     "minimist": "^1.2.6",
     "shell-quote": "^1.7.3"
   },
-  "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
+  "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
+  "peerDependencies": {
+    "rxjs": "^7.8.2"
+  }
 }

--- a/packages/digest-persistence/package.json
+++ b/packages/digest-persistence/package.json
@@ -27,8 +27,7 @@
     "clean": "rm -rf node_modules lib"
   },
   "dependencies": {
-    "@samihult/xjog-util": "^0.0.37",
-    "rxjs": "^7.4.0"
+    "@samihult/xjog-util": "^0.0.37"
   },
   "devDependencies": {
     "@types/jest": "^27.0.1",
@@ -39,5 +38,8 @@
     "prettier": "^2.3.2",
     "typescript": "^4.7.4"
   },
-  "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
+  "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
+  "peerDependencies": {
+    "rxjs": "^7.8.2"
+  }
 }

--- a/packages/digest-reader/package.json
+++ b/packages/digest-reader/package.json
@@ -30,8 +30,7 @@
   },
   "dependencies": {
     "@samihult/xjog-digest-persistence": "^0.0.28",
-    "@samihult/xjog-util": "^0.0.37",
-    "rxjs": "^7.4.0"
+    "@samihult/xjog-util": "^0.0.37"
   },
   "devDependencies": {
     "@types/jest": "^27.0.1",
@@ -43,5 +42,8 @@
     "prettier": "^2.3.2",
     "typescript": "^4.7.4"
   },
-  "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
+  "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
+  "peerDependencies": {
+    "rxjs": "^7.8.2"
+  }
 }

--- a/packages/journal-persistence/package.json
+++ b/packages/journal-persistence/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "@samihult/xjog-util": "^0.0.37",
     "rfc6902": "^5.0.1",
-    "rxjs": "^7.4.0",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
@@ -44,5 +43,8 @@
     "prettier": "^2.3.2",
     "typescript": "^4.7.4"
   },
-  "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
+  "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
+  "peerDependencies": {
+    "rxjs": "^7.8.2"
+  }
 }

--- a/packages/journal-reader/package.json
+++ b/packages/journal-reader/package.json
@@ -30,12 +30,12 @@
   },
   "dependencies": {
     "@samihult/xjog": "^0.0.323",
+    "@samihult/xjog-journal-persistence": "^0.0.56",
     "@samihult/xjog-util": "^0.0.37",
     "pg": "^8.7.3",
     "pg-bind": "^1.0.1",
     "pg-listen": "^1.7.0",
     "rfc6902": "^5.0.1",
-    "rxjs": "^7.4.0",
     "uuid": "^8.3.2",
     "xstate": "4.26.1"
   },
@@ -50,5 +50,8 @@
     "prettier": "^2.3.2",
     "typescript": "^4.7.4"
   },
-  "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
+  "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
+  "peerDependencies": {
+    "rxjs": "^7.8.2"
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2175,20 +2175,6 @@ concat-stream@^2.0.0:
     readable-stream "^3.0.2"
     typedarray "^0.0.6"
 
-concurrently@^6.2.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/concurrently/-/concurrently-6.5.1.tgz#4518c67f7ac680cf5c34d5adf399a2a2047edc8c"
-  integrity sha512-FlSwNpGjWQfRwPLXvJ/OgysbBxPkWpiVjy1042b0U7on7S7qwwMIILRj7WTN1mTgqa582bG6NFuScOoh6Zgdag==
-  dependencies:
-    chalk "^4.1.0"
-    date-fns "^2.16.1"
-    lodash "^4.17.21"
-    rxjs "^6.6.3"
-    spawn-command "^0.0.2-1"
-    supports-color "^8.1.0"
-    tree-kill "^1.2.2"
-    yargs "^16.2.0"
-
 console-control-strings@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
@@ -2323,11 +2309,6 @@ dargs@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/dargs/-/dargs-7.0.0.tgz#04015c41de0bcb69ec84050f3d9be0caf8d6d5cc"
   integrity sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==
-
-date-fns@^2.16.1:
-  version "2.29.3"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
-  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
 dateformat@^3.0.3:
   version "3.0.3"
@@ -5615,17 +5596,17 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^6.6.3:
-  version "6.6.7"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
-  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
-  dependencies:
-    tslib "^1.9.0"
-
-rxjs@^7.4.0, rxjs@^7.5.5:
+rxjs@^7.5.5:
   version "7.5.7"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.7.tgz#2ec0d57fdc89ece220d2e702730ae8f1e49def39"
   integrity sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==
+  dependencies:
+    tslib "^2.1.0"
+
+rxjs@^7.8.2:
+  version "7.8.2"
+  resolved "https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-repo-virtual/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
+  integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
   dependencies:
     tslib "^2.1.0"
 
@@ -5781,11 +5762,6 @@ source-map@^0.7.3:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
   integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
-
-spawn-command@^0.0.2-1:
-  version "0.0.2-1"
-  resolved "https://registry.yarnpkg.com/spawn-command/-/spawn-command-0.0.2-1.tgz#62f5e9466981c1b796dc5929937e11c9c6921bd0"
-  integrity sha512-n98l9E2RMSJ9ON1AKisHzz7V42VDiBQGY6PB1BwRglz99wpVsSuGzQ+jOi6lFXBGVTCrRpltvjm+/XA+tpeJrg==
 
 spdx-correct@^3.0.0:
   version "3.1.1"
@@ -5985,7 +5961,7 @@ supports-color@^7.0.0, supports-color@^7.1.0:
   dependencies:
     has-flag "^4.0.0"
 
-supports-color@^8.0.0, supports-color@^8.1.0:
+supports-color@^8.0.0:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-8.1.1.tgz#cd6fc17e28500cff56c1b86c0a7fd4a54a73005c"
   integrity sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==
@@ -6109,11 +6085,6 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
-tree-kill@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
-  integrity sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
-
 trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
@@ -6147,7 +6118,7 @@ tsconfig-paths@^4.1.2:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
- Move rxjs from direct dependency to peerDependency in core, journal-persistence, journal-reader, digest persistence, and digest-reader to let consuming projects control the version
- Add rxjs ^7.8.2 as workspace root devDependency for monorepo development
- Remove unused concurrently devDependency from core (was pulling in rxjs 6 which shadowed the required v7)
- Add missing @samihult/xjog-journal persistence dependency to journal-reader