### PR TITLE
Fix missing after timers on rehydrate

### DIFF
--- a/packages/core-persistence/src/PersistenceAdapter.ts
+++ b/packages/core-persistence/src/PersistenceAdapter.ts
@@ -247,6 +247,12 @@ export abstract class PersistenceAdapter<
     connection?: ConnectionType,
   ): Promise<PersistedDeferredEvent | null>;
 
+  protected abstract readDeferredEventByEventId(
+    ref: ChartReference,
+    eventId: string | number,
+    connection?: ConnectionType,
+  ): Promise<PersistedDeferredEvent | null>;
+
   /**
    * In ascending order by due time.
    *
@@ -644,6 +650,16 @@ export abstract class PersistenceAdapter<
       trace({ message: 'Done' });
       return insertedEventRow;
     });
+  }
+
+  public async isDeferredEventPresent(
+    ref: ChartReference,
+    eventId: string | number,
+    connection?: ConnectionType,
+  ): Promise<boolean> {
+    return (
+      (await this.readDeferredEventByEventId(ref, eventId, connection)) !== null
+    );
   }
 
   /**

--- a/packages/core-persistence/src/PersistenceAdapter.ts
+++ b/packages/core-persistence/src/PersistenceAdapter.ts
@@ -1,18 +1,16 @@
 import { v4 as uuidV4 } from 'uuid';
-import { EventObject, StateSchema, Typestate, State } from 'xstate';
-
-import {
-  AbstractPersistenceAdapter,
-	type ChartReference,
-  getCorrelationIdentifier,
-} from '@samihult/xjog-util';
-import { v4 as uuidV4 } from 'uuid';
 import {
 	type EventObject,
 	State,
 	type StateSchema,
 	type Typestate,
 } from 'xstate';
+
+import {
+  AbstractPersistenceAdapter,
+  type ChartReference,
+  getCorrelationIdentifier,
+} from '@samihult/xjog-util';
 
 import type { PersistedChart, PersistedDeferredEvent } from './EntryTypes';
 

--- a/packages/core-pg/src/PostgresPersistenceAdapter.ts
+++ b/packages/core-pg/src/PostgresPersistenceAdapter.ts
@@ -663,6 +663,27 @@ export class PostgresPersistenceAdapter extends PersistenceAdapter<PoolClient> {
     return PostgresPersistenceAdapter.parseSqlDeferredEventRow(result.rows[0]);
   }
 
+  protected async readDeferredEventByEventId(
+    ref: ChartReference,
+    eventId: string | number,
+    connection: Pool | PoolClient = this.pool,
+  ): Promise<PersistedDeferredEvent | null> {
+    const result = await connection.query<PostgreSQLDeferredEventRow>(
+      'SELECT ' +
+        this.deferredEventSelectFields +
+        'FROM "deferredEvents" ' +
+        'WHERE "machineId"=$1 AND "chartId"=$2 AND "eventId"=$3 ' +
+        'FOR SHARE',
+      [ref.machineId, ref.chartId, JSON.stringify(eventId)],
+    );
+
+    if (!result.rowCount) {
+      return null;
+    }
+
+    return PostgresPersistenceAdapter.parseSqlDeferredEventRow(result.rows[0]);
+  }
+
   /**
    * Read a batch of deferred events and mark them taken
    * @param instanceId

--- a/packages/core-pglite/src/PGlitePersistenceAdapter.ts
+++ b/packages/core-pglite/src/PGlitePersistenceAdapter.ts
@@ -372,7 +372,7 @@ export class PGlitePersistenceAdapter extends PersistenceAdapter<PGlite> {
       [ref.machineId, ref.chartId],
     );
 
-    if (!result.affectedRows) {
+    if (!result.rows.length) {
       return null;
     }
 
@@ -604,6 +604,27 @@ export class PGlitePersistenceAdapter extends PersistenceAdapter<PGlite> {
         'WHERE "id"=$1 ' +
         'FOR SHARE',
       [id],
+    );
+
+    if (!result.rows.length) {
+      return null;
+    }
+
+    return PGlitePersistenceAdapter.parseSqlDeferredEventRow(result.rows[0]);
+  }
+
+  protected async readDeferredEventByEventId(
+    ref: ChartReference,
+    eventId: string | number,
+    connection: PGlite = this.pool,
+  ): Promise<PersistedDeferredEvent | null> {
+    const result = await connection.query<PGliteDeferredEventRow>(
+      'SELECT ' +
+        this.deferredEventSelectFields +
+        'FROM "deferredEvents" ' +
+        'WHERE "machineId"=$1 AND "chartId"=$2 AND "eventId"=$3 ' +
+        'FOR SHARE',
+      [ref.machineId, ref.chartId, JSON.stringify(eventId)],
     );
 
     if (!result.rows.length) {

--- a/packages/core/src/XJogChart.test.ts
+++ b/packages/core/src/XJogChart.test.ts
@@ -202,7 +202,9 @@ describe('XJogChart missing after repair', () => {
     });
 
     const xJogMachine = new XJogMachine(xJog, machine);
-    const chart = await xJogMachine.createChart({ chartId: 'chart-runstep-after' });
+    const chart = await xJogMachine.createChart({
+      chartId: 'chart-runstep-after',
+    });
 
     (xJogMachine.persistence as any).isDeferredEventPresent = jest
       .fn()

--- a/packages/core/src/XJogChart.test.ts
+++ b/packages/core/src/XJogChart.test.ts
@@ -1,8 +1,9 @@
 import { PGlitePersistenceAdapter } from '@samihult/xjog-core-pglite';
 import { Subject } from 'rxjs';
-import { createMachine } from 'xstate';
+import { createMachine, interpret, State } from 'xstate';
 
 import type { XJog } from './XJog';
+import { XJogChart } from './XJogChart';
 import { XJogMachine } from './XJogMachine';
 
 // PGlite initialisation can take several seconds
@@ -131,5 +132,91 @@ describe('XJogChart: executeActions must run even if changeSubject.next() throws
 
     expect(result).not.toBeNull();
     expect(result?.value).toBe('done');
+  });
+});
+
+describe('XJogChart missing after repair', () => {
+  it('reconstructs missing after-actions when deferred row is absent', async () => {
+    const persistence = await PGlitePersistenceAdapter.connect();
+    const xJog = buildMockXJog(persistence);
+
+    const machine = createMachine({
+      id: 'rehydrate-after-machine',
+      initial: 'waiting',
+      states: {
+        waiting: {
+          after: {
+            1000: 'done',
+          },
+        },
+        done: {
+          type: 'final',
+        },
+      },
+    });
+
+    const xJogMachine = new XJogMachine(xJog, machine);
+    const service = interpret(machine).start();
+    const resolvedState = machine.resolveState(
+      State.create(JSON.parse(JSON.stringify(service.state))),
+    );
+
+    (xJogMachine.persistence as any).isDeferredEventPresent = jest
+      .fn()
+      .mockResolvedValue(false);
+
+    // @ts-expect-error Testing private helper intentionally
+    const repairedActions = await XJogChart.resolveMissingAfterActions(
+      xJogMachine,
+      'chart-with-after',
+      resolvedState,
+    );
+
+    expect(
+      repairedActions.some(
+        (action) =>
+          action.type === 'xstate.send' &&
+          action.id === 'xstate.after(1000)#rehydrate-after-machine.waiting',
+      ),
+    ).toBe(true);
+  });
+
+  it('executes reconstructed after-actions during runStep even when rehydrate actions are skipped', async () => {
+    const persistence = await PGlitePersistenceAdapter.connect();
+    const xJog = buildMockXJog(persistence);
+    xJog.options.startup.skipRunningActionsOnRehydrate = true;
+
+    const machine = createMachine({
+      id: 'rehydrate-runstep-machine',
+      initial: 'waiting',
+      states: {
+        waiting: {
+          after: {
+            1000: 'done',
+          },
+        },
+        done: {
+          type: 'final',
+        },
+      },
+    });
+
+    const xJogMachine = new XJogMachine(xJog, machine);
+    const chart = await xJogMachine.createChart({ chartId: 'chart-runstep-after' });
+
+    (xJogMachine.persistence as any).isDeferredEventPresent = jest
+      .fn()
+      .mockResolvedValue(false);
+
+    const deferSpy = jest.spyOn(xJog.deferredEventManager, 'defer');
+
+    await chart.runStep();
+
+    expect(deferSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventId: 'xstate.after(1000)#rehydrate-runstep-machine.waiting',
+      }),
+      expect.any(String),
+    );
   });
 });

--- a/packages/core/src/XJogChart.ts
+++ b/packages/core/src/XJogChart.ts
@@ -374,7 +374,9 @@ export class XJogChart<
   private static resolveAfterActionsForStateNode<
     TContext,
     TEvent extends EventObject,
-  >(stateNode: StateNode<TContext, any, TEvent>): Array<ActionObject<TContext, TEvent>> {
+  >(
+    stateNode: StateNode<TContext, any, TEvent>,
+  ): Array<ActionObject<TContext, TEvent>> {
     return stateNode.after
       .filter(
         (transition) =>
@@ -382,14 +384,17 @@ export class XJogChart<
           transition.eventType.startsWith('xstate.after(') &&
           typeof transition.delay === 'number',
       )
-      .map((transition) => ({
-        to: undefined,
-        type: ActionTypes.Send,
-        id: transition.eventType,
-        delay: transition.delay,
-        event: { type: transition.eventType },
-        _event: toSCXMLEvent({ type: transition.eventType }),
-      } as ActionObject<TContext, TEvent>));
+      .map(
+        (transition) =>
+          ({
+            to: undefined,
+            type: ActionTypes.Send,
+            id: transition.eventType,
+            delay: transition.delay,
+            event: { type: transition.eventType },
+            _event: toSCXMLEvent({ type: transition.eventType }),
+          } as ActionObject<TContext, TEvent>),
+      );
   }
 
   private async acquireMutex(
@@ -473,20 +478,18 @@ export class XJogChart<
       ];
 
       const rehydratedState = Object.assign(
-        Object.create(
-          Object.getPrototypeOf(this.state),
-        ) as State<TContext, TEvent, TStateSchema, TTypeState>,
+        Object.create(Object.getPrototypeOf(this.state)) as State<
+          TContext,
+          TEvent,
+          TStateSchema,
+          TTypeState
+        >,
         this.state,
         { actions: actionsToExecute },
       );
 
       trace({ message: 'Executing actions' });
-      await this.executeActions(
-        rehydratedState,
-        true,
-        false,
-        cid,
-      );
+      await this.executeActions(rehydratedState, true, false, cid);
 
       trace({ message: 'Emitting next value' });
 

--- a/packages/core/src/XJogChart.ts
+++ b/packages/core/src/XJogChart.ts
@@ -30,6 +30,7 @@ import {
   type SendActionObject,
   type Spawnable,
   State,
+  type StateNode,
   type StateMachine,
   type StateNodeConfig,
   type StateSchema,
@@ -318,6 +319,7 @@ export class XJogChart<
       }
 
       const { state, parentRef } = chart;
+      const resolvedState = xJogMachine.machine.resolveState(state);
 
       return new XJogChart<
         TContext,
@@ -329,10 +331,65 @@ export class XJogChart<
         xJogMachine,
         chartId,
         parentRef,
-        state,
+        resolvedState,
         resolveXJogChartOptions(xJogMachine.xJog.options, xJogMachine.options),
       );
     });
+  }
+
+  private static async resolveMissingAfterActions<
+    TContext,
+    TStateSchema extends StateSchema,
+    TEvent extends EventObject,
+    TTypeState extends Typestate<TContext>,
+  >(
+    xJogMachine: XJogMachine<TContext, TStateSchema, TEvent, TTypeState>,
+    chartId: string,
+    state: State<TContext, TEvent, TStateSchema, TTypeState>,
+  ): Promise<Array<ActionObject<TContext, TEvent>>> {
+    const afterActions = state.configuration.flatMap((stateNode) =>
+      XJogChart.resolveAfterActionsForStateNode(stateNode),
+    );
+
+    const missingAfterActions: Array<ActionObject<TContext, TEvent>> = [];
+
+    for (const action of afterActions) {
+      if (!action.id) {
+        continue;
+      }
+
+      const isPresent = await xJogMachine.persistence.isDeferredEventPresent(
+        { machineId: xJogMachine.id, chartId },
+        action.id,
+      );
+
+      if (!isPresent) {
+        missingAfterActions.push(action);
+      }
+    }
+
+    return missingAfterActions;
+  }
+
+  private static resolveAfterActionsForStateNode<
+    TContext,
+    TEvent extends EventObject,
+  >(stateNode: StateNode<TContext, any, TEvent>): Array<ActionObject<TContext, TEvent>> {
+    return stateNode.transitions
+      .filter(
+        (transition) =>
+          typeof transition.eventType === 'string' &&
+          transition.eventType.startsWith('xstate.after(') &&
+          typeof transition.delay === 'number',
+      )
+      .map((transition) => ({
+        to: undefined,
+        type: ActionTypes.Send,
+        id: transition.eventType,
+        delay: transition.delay,
+        event: { type: transition.eventType },
+        _event: toSCXMLEvent({ type: transition.eventType }),
+      } as ActionObject<TContext, TEvent>));
   }
 
   private async acquireMutex(
@@ -394,8 +451,37 @@ export class XJogChart<
 
       const stateBeforeTransition = JSON.parse(JSON.stringify(this.state));
 
+      const missingAfterActions = await XJogChart.resolveMissingAfterActions(
+        this.xJogMachine,
+        this.chartId,
+        this.state,
+      );
+
+      if (missingAfterActions.length > 0) {
+        trace({
+          message: 'Reconstructing missing after-actions on rehydrate',
+          count: missingAfterActions.length,
+          actionIds: missingAfterActions.map((action) => action.id),
+        });
+      }
+
+      const actionsToExecute = [
+        ...missingAfterActions,
+        ...(this.xJog.options.startup.skipRunningActionsOnRehydrate
+          ? []
+          : this.state.actions),
+      ];
+
       trace({ message: 'Executing actions' });
-      await this.executeActions(this.state, true, false, cid);
+      await this.executeActions(
+        {
+          ...this.state,
+          actions: actionsToExecute,
+        },
+        true,
+        false,
+        cid,
+      );
 
       trace({ message: 'Emitting next value' });
 

--- a/packages/core/src/XJogChart.ts
+++ b/packages/core/src/XJogChart.ts
@@ -375,7 +375,7 @@ export class XJogChart<
     TContext,
     TEvent extends EventObject,
   >(stateNode: StateNode<TContext, any, TEvent>): Array<ActionObject<TContext, TEvent>> {
-    return stateNode.transitions
+    return stateNode.after
       .filter(
         (transition) =>
           typeof transition.eventType === 'string' &&
@@ -472,12 +472,17 @@ export class XJogChart<
           : this.state.actions),
       ];
 
+      const rehydratedState = Object.assign(
+        Object.create(
+          Object.getPrototypeOf(this.state),
+        ) as State<TContext, TEvent, TStateSchema, TTypeState>,
+        this.state,
+        { actions: actionsToExecute },
+      );
+
       trace({ message: 'Executing actions' });
       await this.executeActions(
-        {
-          ...this.state,
-          actions: actionsToExecute,
-        },
+        rehydratedState,
         true,
         false,
         cid,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5605,7 +5605,7 @@ rxjs@^7.5.5:
 
 rxjs@^7.8.2:
   version "7.8.2"
-  resolved "https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-repo-virtual/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.8.2.tgz#955bc473ed8af11a002a2be52071bf475638607b"
   integrity sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==
   dependencies:
     tslib "^2.1.0"


### PR DESCRIPTION
## Summary
- repair missing `xstate.after(...)` timers during chart rehydrate/adoption by reconstructing only the missing delayed send actions
- execute those repaired after-actions during `runStep()` even when `skipRunningActionsOnRehydrate = true`, while keeping ordinary rehydrate actions skipped
- add persistence lookups for deferred events by `eventId` and fix the pglite `readChart()` row check used by tests

## Testing
- `pnpm --filter=@samihult/xjog test -- XJogChart.test.ts`
- `pnpm --filter=@samihult/xjog-core-pglite test -- PGlitePersistenceAdapter.test.ts`