### PR TITLE
Fix deferred event scheduling race

### DIFF
--- a/packages/core-persistence/src/PersistenceAdapter.ts
+++ b/packages/core-persistence/src/PersistenceAdapter.ts
@@ -229,7 +229,7 @@ export abstract class PersistenceAdapter<
    * @returns Inserted id
    */
   protected abstract insertDeferredEvent(
-    deferredEventRow: Omit<PersistedDeferredEvent, 'id' | 'due' | 'timestamp'>,
+    deferredEventRow: Omit<PersistedDeferredEvent, 'id'>,
     connection?: ConnectionType,
   ): Promise<PersistedDeferredEvent | null>;
 
@@ -622,9 +622,14 @@ export abstract class PersistenceAdapter<
       });
 
     return await this.withTransaction(async (connection) => {
+      const timestamp = Date.now();
+      const due = timestamp + Math.ceil(deferredEventRow.delay);
+
       trace({
         message: 'Inserting deferred event into the database',
         delay: deferredEventRow.delay,
+        timestamp,
+        due,
       });
 
       const insertedEventRow = await this.insertDeferredEvent(
@@ -633,7 +638,9 @@ export abstract class PersistenceAdapter<
           eventId: deferredEventRow.eventId ?? uuidV4(),
           eventTo: deferredEventRow.eventTo ?? null,
           event: deferredEventRow.event,
+          timestamp,
           delay: deferredEventRow.delay,
+          due,
           lock: deferredEventRow.lock,
         },
         connection,

--- a/packages/core-pg/src/PostgresPersistenceAdapter.ts
+++ b/packages/core-pg/src/PostgresPersistenceAdapter.ts
@@ -761,12 +761,15 @@ export class PostgresPersistenceAdapter extends PersistenceAdapter<PoolClient> {
   }
 
   protected async insertDeferredEvent(
-    PersistedDeferredEvent: Omit<
-      PersistedDeferredEvent,
-      'id' | 'due' | 'timestamp'
-    >,
+    PersistedDeferredEvent: Omit<PersistedDeferredEvent, 'id'>,
     connection: Pool | PoolClient = this.pool,
   ): Promise<PersistedDeferredEvent | null> {
+    const timestamp =
+      PersistedDeferredEvent.timestamp ?? Date.now();
+    const due =
+      PersistedDeferredEvent.due ??
+      timestamp + Math.ceil(PersistedDeferredEvent.delay);
+
     let toFieldStringRepresentation = null;
 
     if (PersistedDeferredEvent.eventTo) {
@@ -799,14 +802,14 @@ export class PostgresPersistenceAdapter extends PersistenceAdapter<PoolClient> {
           '  "eventId", "eventTo", "event", ' +
           '  "timestamp", "delay", ' +
           '  "due" ' +
-          ') VALUES (' +
+        ') VALUES (' +
           '  :machineId, :chartId, ' +
           '  :eventId, :eventTo, :event, ' +
-          '  transaction_timestamp(), :delay::bigint, ' +
-          '  transaction_timestamp() + make_interval(secs => :delay::bigint / 1000)' +
-          ') ' +
-          'RETURNING ' +
-          this.deferredEventSelectFields,
+          '  :timestamp_iso::timestamptz, :delay::bigint, ' +
+          '  :due_iso::timestamptz' +
+        ') ' +
+        'RETURNING ' +
+        this.deferredEventSelectFields,
         {
           machineId: PersistedDeferredEvent.ref.machineId,
           chartId: PersistedDeferredEvent.ref.chartId,
@@ -815,7 +818,9 @@ export class PostgresPersistenceAdapter extends PersistenceAdapter<PoolClient> {
           eventTo: JSON.stringify(toFieldStringRepresentation),
           event: JSON.stringify(PersistedDeferredEvent.event),
 
+          timestamp_iso: new Date(timestamp).toISOString(),
           delay: Math.ceil(PersistedDeferredEvent.delay),
+          due_iso: new Date(due).toISOString(),
         },
       ),
     );

--- a/packages/core-pglite/src/PGlitePersistenceAdapter.test.ts
+++ b/packages/core-pglite/src/PGlitePersistenceAdapter.test.ts
@@ -108,6 +108,36 @@ describe('PGlitePersistenceAdapter', () => {
     expect(event).toBeUndefined();
   });
 
+  it('should return a near-immediate due time for zero-delay events', async () => {
+    const adapter = await PGlitePersistenceAdapter.connect();
+
+    await adapter.withTransaction(async (client) => {
+      return client.exec('DELETE FROM "deferredEvents"');
+    });
+
+    const before = Date.now();
+    const event = await adapter.deferEvent({
+      ref: {
+        machineId: 'machineId',
+        chartId: 'chartId',
+      },
+      event: {
+        type: 'internal',
+        name: 'test-zero-delay',
+        data: {},
+        $$type: 'scxml',
+      },
+      eventTo: null,
+      delay: 0,
+      lock: null,
+    });
+    const after = Date.now();
+
+    expect(event.delay).toBe(0);
+    expect(Number(event.due)).toBeGreaterThanOrEqual(before - 50);
+    expect(Number(event.due)).toBeLessThanOrEqual(after + 50);
+  });
+
   it('should release deferred events', async () => {
     const adapter = await PGlitePersistenceAdapter.connect();
     const event = await adapter.releaseDeferredEvent(

--- a/packages/core-pglite/src/PGlitePersistenceAdapter.ts
+++ b/packages/core-pglite/src/PGlitePersistenceAdapter.ts
@@ -715,12 +715,14 @@ export class PGlitePersistenceAdapter extends PersistenceAdapter<PGlite> {
   }
 
   protected async insertDeferredEvent(
-    PersistedDeferredEvent: Omit<
-      PersistedDeferredEvent,
-      'id' | 'due' | 'timestamp'
-    >,
+    PersistedDeferredEvent: Omit<PersistedDeferredEvent, 'id'>,
     connection: PGlite = this.pool,
   ): Promise<PersistedDeferredEvent | null> {
+    const timestamp = PersistedDeferredEvent.timestamp ?? Date.now();
+    const due =
+      PersistedDeferredEvent.due ??
+      timestamp + Math.ceil(PersistedDeferredEvent.delay);
+
     let toFieldStringRepresentation = null;
 
     if (PersistedDeferredEvent.eventTo) {
@@ -755,8 +757,8 @@ export class PGlitePersistenceAdapter extends PersistenceAdapter<PGlite> {
         ') VALUES (' +
         '  $1, $2, ' +
         '  $3, $4, $5, ' +
-        '  transaction_timestamp(), $6::bigint, ' +
-        '  transaction_timestamp() + make_interval(secs => $6::bigint / 1000)' +
+        '  $6, $7::bigint, ' +
+        '  $8' +
         ') ' +
         'RETURNING ' +
         this.deferredEventSelectFields,
@@ -766,7 +768,9 @@ export class PGlitePersistenceAdapter extends PersistenceAdapter<PGlite> {
         JSON.stringify(PersistedDeferredEvent.eventId), // $3
         JSON.stringify(toFieldStringRepresentation), // $4
         JSON.stringify(PersistedDeferredEvent.event), // $5
-        Math.ceil(PersistedDeferredEvent.delay), // $6
+        new Date(timestamp).toISOString(), // $6
+        Math.ceil(PersistedDeferredEvent.delay), // $7
+        new Date(due).toISOString(), // $8
       ],
     );
 

--- a/packages/core/src/XJogDeferredEventManager.test.ts
+++ b/packages/core/src/XJogDeferredEventManager.test.ts
@@ -8,6 +8,45 @@ import { XJogDeferredEventManager } from './XJogDeferredEventManager';
 import { ResolvedXJogOptions } from './XJogOptions';
 import { XJog } from './XJog';
 
+function createInMemoryPersistence(
+  delayTakeUpcomingByMs = 0,
+): PersistenceAdapter {
+  let nextId = 1;
+  const deferredEvents: any[] = [];
+
+  return {
+    deferEvent: jest.fn(async (event) => {
+      deferredEvents.push({
+        ...event,
+        id: nextId++,
+        timestamp: Date.now(),
+        due: Date.now() + event.delay,
+      });
+    }),
+    takeUpcomingDeferredEvents: jest.fn(async () => {
+      if (delayTakeUpcomingByMs > 0) {
+        await waitFor(delayTakeUpcomingByMs);
+      }
+
+      const now = Date.now();
+      return deferredEvents.filter(
+        (event) => event.lock === null && event.due <= now + 1000,
+      );
+    }),
+    removeDeferredEvent: jest.fn(async (event) => {
+      const index = deferredEvents.findIndex((item) => item.id === event.id);
+      if (index >= 0) {
+        deferredEvents.splice(index, 1);
+      }
+    }),
+    releaseAllDeferredEvents: jest.fn(async () => {
+      for (const event of deferredEvents) {
+        event.lock = null;
+      }
+    }),
+  } as unknown as PersistenceAdapter;
+}
+
 function mockXJogWithDeferredEventManager(
   persistence: PersistenceAdapter,
   options: ResolvedXJogOptions['deferredEvents'],
@@ -18,7 +57,7 @@ function mockXJogWithDeferredEventManager(
     dying: false,
     persistence,
     trace: trace ? console.log : () => {},
-    timeExecution: jest.fn(),
+    timeExecution: jest.fn(async (_name, fn) => await fn()),
     options: {
       deferredEvents: options,
     },
@@ -358,6 +397,43 @@ describe('XJogDeferredEventManager', () => {
       // The event should never have been sent
       expect(xJog.sendEvent).not.toHaveBeenCalled();
     } finally {
+      await deferredEventManager.releaseAll();
+    }
+  });
+
+  it('does not let an ongoing scheduleUpcoming overwrite an earlier due-now wake-up', async () => {
+    const persistence = createInMemoryPersistence(20);
+    const [xJog, deferredEventManager] = mockXJogWithDeferredEventManager(
+      persistence,
+      {
+        batchSize: 5,
+        lookAhead: 1000,
+        interval: 1000,
+      },
+    );
+
+    try {
+      const ref = { machineId: 'A', chartId: '1' };
+      const event = toSCXMLEvent('event name');
+
+      const scheduling = deferredEventManager.scheduleUpcoming();
+
+      await waitFor(1);
+      await deferredEventManager.defer({ eventId: 'e', ref, event, delay: 0 });
+      await scheduling;
+
+      await waitFor(50);
+
+      expect(xJog.sendEvent).toHaveBeenCalledWith(
+        ref,
+        event,
+        undefined,
+        undefined,
+        expect.stringMatching(/.+/),
+      );
+    } finally {
+      // @ts-ignore test-only shutdown flag
+      xJog.dying = true;
       await deferredEventManager.releaseAll();
     }
   });

--- a/packages/core/src/XJogDeferredEventManager.ts
+++ b/packages/core/src/XJogDeferredEventManager.ts
@@ -85,6 +85,20 @@ export class XJogDeferredEventManager {
     return nextReadDelay;
   }
 
+  /**
+   * Schedule the next read only if there is no earlier wake-up already queued.
+   */
+  private rescheduleNextReadNoLaterThan(due: number): number {
+    if (
+      this.deferredEventHandlerTimer !== null &&
+      this.nextReadAt <= due
+    ) {
+      return Math.max(this.nextReadAt - Date.now(), 0);
+    }
+
+    return this.rescheduleNextReadAt(due);
+  }
+
   public async defer(
     PersistedDeferredEvent: Omit<
       PersistedDeferredEvent,
@@ -169,6 +183,7 @@ export class XJogDeferredEventManager {
       });
 
     this.deferredEventHandlerTimer = null;
+    this.nextReadAt = Number.MAX_SAFE_INTEGER;
 
     // If dying, don't schedule anything new
     if (this.xJog.dying) {
@@ -200,17 +215,17 @@ export class XJogDeferredEventManager {
             'Scheduling next read after the due time of the last deferred event',
           at: lastDeferredEvent,
         });
-        this.rescheduleNextReadAt(lastDeferredEvent.due);
+        this.rescheduleNextReadNoLaterThan(lastDeferredEvent.due);
       } else {
         trace({ message: 'Scheduling next read immediately' });
-        this.rescheduleNextReadAfter(0);
+        this.rescheduleNextReadNoLaterThan(Date.now());
       }
     }
 
     // If we read less items than the batch size, there are no items to be
     // expected during the read interval. Schedule a regular read after that.
     else {
-      this.rescheduleNextReadAfter(this.options.interval);
+      this.rescheduleNextReadNoLaterThan(Date.now() + this.options.interval);
       trace({
         message: 'Scheduling next read after the regular interval',
         after: this.options.interval,

--- a/packages/core/src/XJogDeferredEventManager.ts
+++ b/packages/core/src/XJogDeferredEventManager.ts
@@ -89,10 +89,7 @@ export class XJogDeferredEventManager {
    * Schedule the next read only if there is no earlier wake-up already queued.
    */
   private rescheduleNextReadNoLaterThan(due: number): number {
-    if (
-      this.deferredEventHandlerTimer !== null &&
-      this.nextReadAt <= due
-    ) {
+    if (this.deferredEventHandlerTimer !== null && this.nextReadAt <= due) {
       return Math.max(this.nextReadAt - Date.now(), 0);
     }
 


### PR DESCRIPTION
## Summary
- persist deferred event `timestamp` and `due` values at defer-time instead of recomputing them inside adapter inserts
- prevent `scheduleUpcoming()` from replacing an already-earlier wake-up with a later timer while a concurrent read is still in flight
- add regression coverage for zero-delay deferred events and the scheduler race that could delay immediate delivery

## Bugfix
Deferred events could be scheduled later than intended when a due-now event was added while `scheduleUpcoming()` was already running. The in-flight scheduler pass could overwrite the earlier wake-up with a later timer, causing immediate events to wait until the regular polling interval or last batch due time.

This change computes `timestamp` and `due` once when deferring the event, persists those exact values through the persistence adapters, and only reschedules the next read when the new target is not later than an existing wake-up.

## Testing
- node --experimental-vm-modules node_modules/.bin/jest --config jestconfig.js src/XJogDeferredEventManager.test.ts
- yarn lerna run lint --scope @samihult/xjog-core-pglite