### PR TITLE
Centralize workspace dev tooling for pnpm

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,21 @@
     ]
   },
   "devDependencies": {
+    "@swc/cli": "^0.1.57",
+    "@swc/core": "^1.2.223",
+    "@swc/jest": "^0.2.22",
+    "@types/jest": "^27.0.1",
+    "@types/node": "^16.7.10",
+    "@typescript-eslint/eslint-plugin": "^5.40.0",
+    "@typescript-eslint/parser": "^5.40.0",
+    "cpx-fixed": "^1.6.0",
+    "eslint": "^8.25.0",
+    "eslint-config-prettier": "^8.5.0",
+    "jest": "^28.1.2",
     "lerna": "7.4.2",
-    "rxjs": "^7.8.2"
+    "prettier": "^2.3.2",
+    "rxjs": "^7.8.2",
+    "ts-node": "^10.7.0",
+    "typescript": "^4.7.4"
   }
 }

--- a/packages/core-persistence/package.json
+++ b/packages/core-persistence/package.json
@@ -23,8 +23,8 @@
   ],
   "scripts": {
     "build": "pnpm run build:bin && pnpm run build:files",
-    "build:bin": "tsc",
-    "build:files": "cpx-fixed 'src/**/*.sql' lib",
+    "build:bin": "pnpm exec tsc",
+    "build:files": "pnpm exec cpx-fixed 'src/**/*.sql' lib",
     "prePublishOnly": "pnpm run build",
     "clean": "rm -rf node_modules lib"
   },
@@ -34,15 +34,7 @@
     "xstate": "4.26.1"
   },
   "devDependencies": {
-    "@types/jest": "^27.0.1",
-    "@types/node": "^16.7.10",
-    "@types/uuid": "^8.3.1",
-    "@typescript-eslint/eslint-plugin": "^5.40.0",
-    "@typescript-eslint/parser": "^5.40.0",
-    "cpx-fixed": "^1.6.0",
-    "jest": "^28.1.2",
-    "prettier": "^2.3.2",
-    "typescript": "^4.7.4"
+    "@types/uuid": "^8.3.1"
   },
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
 }

--- a/packages/core-pg/package.json
+++ b/packages/core-pg/package.json
@@ -23,8 +23,8 @@
   ],
   "scripts": {
     "build": "pnpm run build:bin && pnpm run build:files",
-    "build:bin": "tsc",
-    "build:files": "cpx-fixed 'src/**/*.sql' lib",
+    "build:bin": "pnpm exec tsc",
+    "build:files": "pnpm exec cpx-fixed 'src/**/*.sql' lib",
     "prePublishOnly": "pnpm run build",
     "clean": "rm -rf node_modules lib"
   },
@@ -40,15 +40,7 @@
     "xstate": "4.26.1"
   },
   "devDependencies": {
-    "@types/jest": "^27.0.1",
-    "@types/node": "^16.7.10",
-    "@types/pg": "^8.6.5",
-    "@typescript-eslint/eslint-plugin": "^5.40.0",
-    "@typescript-eslint/parser": "^5.40.0",
-    "cpx-fixed": "^1.6.0",
-    "jest": "^28.1.2",
-    "prettier": "^2.3.2",
-    "typescript": "^4.7.4"
+    "@types/pg": "^8.6.5"
   },
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
 }

--- a/packages/core-pglite/package.json
+++ b/packages/core-pglite/package.json
@@ -18,34 +18,21 @@
   ],
   "scripts": {
     "build": "pnpm run build:bin && pnpm run build:files",
-    "build:bin": "tsc",
-    "build:files": "cpx-fixed 'src/**/*.sql' lib",
+    "build:bin": "pnpm exec tsc",
+    "build:files": "pnpm exec cpx-fixed 'src/**/*.sql' lib",
     "clean": "rm -rf node_modules lib",
-    "format": "prettier --write 'src/**/*.ts'",
-    "lint": "eslint src/**/*.ts && prettier --check src",
+    "format": "pnpm exec prettier --write 'src/**/*.ts'",
+    "lint": "pnpm exec eslint src/**/*.ts && pnpm exec prettier --check src",
     "prePublishOnly": "pnpm run build",
-    "test": "NODE_OPTIONS='--experimental-vm-modules' jest"
+    "test": "NODE_OPTIONS='--experimental-vm-modules' pnpm exec jest"
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.3.5",
     "@samihult/xjog-core-persistence": "workspace:^",
     "@samihult/xjog-util": "workspace:^",
-    "node-pg-migrate": "^6.2.1"
-  },
-  "devDependencies": {
-    "@swc/cli": "^0.1.57",
-    "@swc/core": "^1.2.223",
-    "@swc/jest": "^0.2.22",
-    "@types/jest": "^27.0.1",
-    "@types/node": "^16.7.10",
-    "cpx-fixed": "^1.6.0",
-    "eslint": "^8.25.0",
-    "eslint-config-prettier": "^8.5.0",
-    "jest": "^28.1.2",
-    "prettier": "^2.3.2",
-    "ts-node": "^10.7.0",
-    "typescript": "^4.7.4",
+    "node-pg-migrate": "^6.2.1",
     "xstate": "4.26.1"
   },
+  "devDependencies": {},
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,10 +22,10 @@
     "lib/**/*"
   ],
   "scripts": {
-    "build": "tsc",
-    "test": "NODE_OPTIONS='--experimental-vm-modules' jest --config jestconfig.js --passWithNoTests",
-    "lint": "eslint src/**/*.ts && prettier --check src",
-    "format": "prettier --write 'src/**/*.ts'",
+    "build": "pnpm exec tsc",
+    "test": "NODE_OPTIONS='--experimental-vm-modules' pnpm exec jest --config jestconfig.js --passWithNoTests",
+    "lint": "pnpm exec eslint src/**/*.ts && pnpm exec prettier --check src",
+    "format": "pnpm exec prettier --write 'src/**/*.ts'",
     "prepublishOnly": "pnpm run lint && pnpm run build && echo 'should also run: pnpm run test + pnpm run check'",
     "clean": "rm -rf node_modules lib"
   },
@@ -38,24 +38,10 @@
   },
   "devDependencies": {
     "@samihult/xjog-core-pglite": "workspace:^",
-    "@swc/cli": "^0.1.57",
-    "@swc/core": "^1.2.223",
-    "@swc/jest": "^0.2.22",
     "@types/express": "^4.17.13",
-    "@types/jest": "^27.0.1",
-    "@types/node": "^16.7.10",
     "@types/pg": "^8.6.5",
     "@types/uuid": "^8.3.1",
-    "@typescript-eslint/eslint-plugin": "^5.40.0",
-    "@typescript-eslint/parser": "^5.40.0",
-    "cpx-fixed": "^1.6.0",
-    "eslint": "^8.25.0",
-    "eslint-config-prettier": "^8.5.0",
-    "glob": "^8.0.3",
-    "jest": "^28.1.2",
-    "prettier": "^2.3.2",
-    "ts-node": "^10.7.0",
-    "typescript": "^4.7.4"
+    "glob": "^8.0.3"
   },
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
   "peerDependencies": {

--- a/packages/digest-persistence/package.json
+++ b/packages/digest-persistence/package.json
@@ -22,22 +22,14 @@
     "lib/**/*"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "pnpm exec tsc",
     "prePublishOnly": "pnpm run build",
     "clean": "rm -rf node_modules lib"
   },
   "dependencies": {
     "@samihult/xjog-util": "workspace:^"
   },
-  "devDependencies": {
-    "@types/jest": "^27.0.1",
-    "@types/node": "^16.7.10",
-    "@typescript-eslint/eslint-plugin": "^5.40.0",
-    "@typescript-eslint/parser": "^5.40.0",
-    "jest": "^28.1.2",
-    "prettier": "^2.3.2",
-    "typescript": "^4.7.4"
-  },
+  "devDependencies": {},
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
   "peerDependencies": {
     "rxjs": "^7.8.2"

--- a/packages/digest-pg/package.json
+++ b/packages/digest-pg/package.json
@@ -23,8 +23,8 @@
   ],
   "scripts": {
     "build": "pnpm run build:bin && pnpm run build:files",
-    "build:bin": "tsc",
-    "build:files": "cpx-fixed 'src/**/*.sql' lib",
+    "build:bin": "pnpm exec tsc",
+    "build:files": "pnpm exec cpx-fixed 'src/**/*.sql' lib",
     "prePublishOnly": "pnpm run build",
     "clean": "rm -rf node_modules lib"
   },
@@ -39,15 +39,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@types/jest": "^27.0.1",
-    "@types/node": "^16.7.10",
-    "@types/pg": "^8.6.5",
-    "@typescript-eslint/eslint-plugin": "^5.40.0",
-    "@typescript-eslint/parser": "^5.40.0",
-    "cpx-fixed": "^1.6.0",
-    "jest": "^28.1.2",
-    "prettier": "^2.3.2",
-    "typescript": "^4.7.4"
+    "@types/pg": "^8.6.5"
   },
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
 }

--- a/packages/digest-pglite/package.json
+++ b/packages/digest-pglite/package.json
@@ -14,11 +14,11 @@
   ],
   "scripts": {
     "build": "pnpm run build:bin && pnpm run build:files",
-    "build:bin": "tsc",
-    "lint": "eslint src/**/*.ts && prettier --check src",
-    "build:files": "cpx-fixed 'src/**/*.sql' lib",
+    "build:bin": "pnpm exec tsc",
+    "lint": "pnpm exec eslint src/**/*.ts && pnpm exec prettier --check src",
+    "build:files": "pnpm exec cpx-fixed 'src/**/*.sql' lib",
     "clean": "rm -rf node_modules lib",
-    "test": "NODE_OPTIONS='--experimental-vm-modules' jest"
+    "test": "NODE_OPTIONS='--experimental-vm-modules' pnpm exec jest"
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.3.5",
@@ -26,18 +26,5 @@
     "@samihult/xjog-util": "workspace:^",
     "node-pg-migrate": "^6.2.1"
   },
-  "devDependencies": {
-    "@swc/cli": "^0.1.57",
-    "@swc/core": "^1.2.223",
-    "@swc/jest": "^0.2.22",
-    "@types/jest": "^27.0.1",
-    "@types/node": "^16.7.10",
-    "cpx-fixed": "^1.6.0",
-    "eslint": "^8.25.0",
-    "eslint-config-prettier": "^8.5.0",
-    "jest": "^28.1.2",
-    "prettier": "^2.3.2",
-    "ts-node": "^10.7.0",
-    "typescript": "^4.7.4"
-  }
+  "devDependencies": {}
 }

--- a/packages/digest-reader/package.json
+++ b/packages/digest-reader/package.json
@@ -23,8 +23,8 @@
   ],
   "scripts": {
     "build": "pnpm run build:bin && pnpm run build:files",
-    "build:bin": "tsc",
-    "build:files": "cpx-fixed 'src/**/*.sql' lib",
+    "build:bin": "pnpm exec tsc",
+    "build:files": "pnpm exec cpx-fixed 'src/**/*.sql' lib",
     "prePublishOnly": "pnpm run build",
     "clean": "rm -rf node_modules lib"
   },
@@ -32,16 +32,7 @@
     "@samihult/xjog-digest-persistence": "workspace:^",
     "@samihult/xjog-util": "workspace:^"
   },
-  "devDependencies": {
-    "@types/jest": "^27.0.1",
-    "@types/node": "^16.7.10",
-    "@typescript-eslint/eslint-plugin": "^5.40.0",
-    "@typescript-eslint/parser": "^5.40.0",
-    "cpx-fixed": "^1.6.0",
-    "jest": "^28.1.2",
-    "prettier": "^2.3.2",
-    "typescript": "^4.7.4"
-  },
+  "devDependencies": {},
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
   "peerDependencies": {
     "rxjs": "^7.8.2"

--- a/packages/digest-writer/package.json
+++ b/packages/digest-writer/package.json
@@ -23,8 +23,8 @@
   ],
   "scripts": {
     "build": "pnpm run build:bin && pnpm run build:files",
-    "build:bin": "tsc",
-    "build:files": "cpx-fixed 'src/**/*.sql' lib",
+    "build:bin": "pnpm exec tsc",
+    "build:files": "pnpm exec cpx-fixed 'src/**/*.sql' lib",
     "prePublishOnly": "pnpm run build",
     "clean": "rm -rf node_modules lib"
   },
@@ -38,15 +38,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@types/jest": "^27.0.1",
-    "@types/node": "^16.7.10",
-    "@types/pg": "^8.6.5",
-    "@typescript-eslint/eslint-plugin": "^5.40.0",
-    "@typescript-eslint/parser": "^5.40.0",
-    "cpx-fixed": "^1.6.0",
-    "jest": "^28.1.2",
-    "prettier": "^2.3.2",
-    "typescript": "^4.7.4"
+    "@types/pg": "^8.6.5"
   },
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
 }

--- a/packages/journal-persistence/package.json
+++ b/packages/journal-persistence/package.json
@@ -23,8 +23,8 @@
   ],
   "scripts": {
     "build": "pnpm run build:bin && pnpm run build:files",
-    "build:bin": "tsc",
-    "build:files": "cpx-fixed 'src/**/*.sql' lib",
+    "build:bin": "pnpm exec tsc",
+    "build:files": "pnpm exec cpx-fixed 'src/**/*.sql' lib",
     "prePublishOnly": "pnpm run build",
     "clean": "rm -rf node_modules lib"
   },
@@ -34,16 +34,7 @@
     "uuid": "^8.3.2",
     "xstate": "4.26.1"
   },
-  "devDependencies": {
-    "@types/jest": "^27.0.1",
-    "@types/node": "^16.7.10",
-    "@typescript-eslint/eslint-plugin": "^5.40.0",
-    "@typescript-eslint/parser": "^5.40.0",
-    "cpx-fixed": "^1.6.0",
-    "jest": "^28.1.2",
-    "prettier": "^2.3.2",
-    "typescript": "^4.7.4"
-  },
+  "devDependencies": {},
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
   "peerDependencies": {
     "rxjs": "^7.8.2"

--- a/packages/journal-pg/package.json
+++ b/packages/journal-pg/package.json
@@ -23,8 +23,8 @@
   ],
   "scripts": {
     "build": "pnpm run build:bin && pnpm run build:files",
-    "build:bin": "tsc",
-    "build:files": "cpx-fixed 'src/**/*.sql' lib",
+    "build:bin": "pnpm exec tsc",
+    "build:files": "pnpm exec cpx-fixed 'src/**/*.sql' lib",
     "prePublishOnly": "pnpm run build",
     "clean": "rm -rf node_modules lib"
   },
@@ -40,15 +40,7 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "@types/jest": "^27.0.1",
-    "@types/node": "^16.7.10",
-    "@types/pg": "^8.6.5",
-    "@typescript-eslint/eslint-plugin": "^5.40.0",
-    "@typescript-eslint/parser": "^5.40.0",
-    "cpx-fixed": "^1.6.0",
-    "jest": "^28.1.2",
-    "prettier": "^2.3.2",
-    "typescript": "^4.7.4"
+    "@types/pg": "^8.6.5"
   },
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
 }

--- a/packages/journal-pglite/package.json
+++ b/packages/journal-pglite/package.json
@@ -14,11 +14,11 @@
   ],
   "scripts": {
     "build": "pnpm run build:bin && pnpm run build:files",
-    "build:bin": "tsc",
-    "lint": "eslint src/**/*.ts && prettier --check src",
-    "build:files": "cpx-fixed 'src/**/*.sql' lib",
+    "build:bin": "pnpm exec tsc",
+    "lint": "pnpm exec eslint src/**/*.ts && pnpm exec prettier --check src",
+    "build:files": "pnpm exec cpx-fixed 'src/**/*.sql' lib",
     "clean": "rm -rf node_modules lib",
-    "test": "NODE_OPTIONS='--experimental-vm-modules' jest"
+    "test": "NODE_OPTIONS='--experimental-vm-modules' pnpm exec jest"
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.3.5",
@@ -27,14 +27,5 @@
     "xstate": "4.26.1",
     "node-pg-migrate": "^6.2.1"
   },
-  "devDependencies": {
-    "@types/node": "^16.7.10",
-    "cpx-fixed": "^1.6.0",
-    "eslint": "^8.25.0",
-    "eslint-config-prettier": "^8.5.0",
-    "jest": "^28.1.2",
-    "prettier": "^2.3.2",
-    "ts-node": "^10.7.0",
-    "typescript": "^4.7.4"
-  }
+  "devDependencies": {}
 }

--- a/packages/journal-reader/package.json
+++ b/packages/journal-reader/package.json
@@ -23,8 +23,8 @@
   ],
   "scripts": {
     "build": "pnpm run build:bin && pnpm run build:files",
-    "build:bin": "tsc",
-    "build:files": "cpx-fixed 'src/**/*.sql' lib",
+    "build:bin": "pnpm exec tsc",
+    "build:files": "pnpm exec cpx-fixed 'src/**/*.sql' lib",
     "prePublishOnly": "pnpm run build",
     "clean": "rm -rf node_modules lib"
   },
@@ -40,15 +40,7 @@
     "xstate": "4.26.1"
   },
   "devDependencies": {
-    "@types/jest": "^27.0.1",
-    "@types/node": "^16.7.10",
-    "@types/pg": "^8.6.5",
-    "@typescript-eslint/eslint-plugin": "^5.40.0",
-    "@typescript-eslint/parser": "^5.40.0",
-    "cpx-fixed": "^1.6.0",
-    "jest": "^28.1.2",
-    "prettier": "^2.3.2",
-    "typescript": "^4.7.4"
+    "@types/pg": "^8.6.5"
   },
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
   "peerDependencies": {

--- a/packages/journal-writer/package.json
+++ b/packages/journal-writer/package.json
@@ -22,7 +22,7 @@
     "lib/**/*"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "pnpm exec tsc",
     "prePublishOnly": "pnpm run build",
     "clean": "rm -rf node_modules lib"
   },
@@ -31,14 +31,6 @@
     "@samihult/xjog-journal-persistence": "workspace:^",
     "@samihult/xjog-util": "workspace:^"
   },
-  "devDependencies": {
-    "@types/jest": "^27.0.1",
-    "@types/node": "^16.7.10",
-    "@typescript-eslint/eslint-plugin": "^5.40.0",
-    "@typescript-eslint/parser": "^5.40.0",
-    "jest": "^28.1.2",
-    "prettier": "^2.3.2",
-    "typescript": "^4.7.4"
-  },
+  "devDependencies": {},
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
 }

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -22,7 +22,7 @@
     "lib/**/*"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "pnpm exec tsc",
     "prePublishOnly": "pnpm run build",
     "clean": "rm -rf node_modules lib"
   },
@@ -30,14 +30,6 @@
     "rfc6902": "^5.0.1",
     "xstate": "4.26.1"
   },
-  "devDependencies": {
-    "@types/jest": "^27.0.1",
-    "@types/node": "^16.7.10",
-    "@typescript-eslint/eslint-plugin": "^5.40.0",
-    "@typescript-eslint/parser": "^5.40.0",
-    "jest": "^28.1.2",
-    "prettier": "^2.3.2",
-    "typescript": "^4.7.4"
-  },
+  "devDependencies": {},
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,12 +13,54 @@ importers:
 
   .:
     devDependencies:
+      '@swc/cli':
+        specifier: ^0.1.57
+        version: 0.1.65(@swc/core@1.15.24)
+      '@swc/core':
+        specifier: ^1.2.223
+        version: 1.15.24
+      '@swc/jest':
+        specifier: ^0.2.22
+        version: 0.2.39(@swc/core@1.15.24)
+      '@types/jest':
+        specifier: ^27.0.1
+        version: 27.5.2
+      '@types/node':
+        specifier: ^16.7.10
+        version: 16.18.126
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^5.40.0
+        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
+      '@typescript-eslint/parser':
+        specifier: ^5.40.0
+        version: 5.62.0(eslint@8.57.1)(typescript@4.9.5)
+      cpx-fixed:
+        specifier: ^1.6.0
+        version: 1.6.0
+      eslint:
+        specifier: ^8.25.0
+        version: 8.57.1
+      eslint-config-prettier:
+        specifier: ^8.5.0
+        version: 8.10.2(eslint@8.57.1)
+      jest:
+        specifier: ^28.1.2
+        version: 28.1.3(@types/node@16.18.126)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5))
       lerna:
         specifier: 7.4.2
-        version: 7.4.2(@swc/core@1.15.24)(encoding@0.1.13)
+        version: 7.4.2(@swc/core@1.15.24)(@types/node@16.18.126)(encoding@0.1.13)
+      prettier:
+        specifier: ^2.3.2
+        version: 2.8.8
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
+      ts-node:
+        specifier: ^10.7.0
+        version: 10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5)
+      typescript:
+        specifier: ^4.7.4
+        version: 4.9.5
 
   packages/core:
     dependencies:
@@ -44,60 +86,18 @@ importers:
       '@samihult/xjog-core-pglite':
         specifier: workspace:^
         version: link:../core-pglite
-      '@swc/cli':
-        specifier: ^0.1.57
-        version: 0.1.65(@swc/core@1.15.24)
-      '@swc/core':
-        specifier: ^1.2.223
-        version: 1.15.24
-      '@swc/jest':
-        specifier: ^0.2.22
-        version: 0.2.39(@swc/core@1.15.24)
       '@types/express':
         specifier: ^4.17.13
         version: 4.17.25
-      '@types/jest':
-        specifier: ^27.0.1
-        version: 27.5.2
-      '@types/node':
-        specifier: ^16.7.10
-        version: 16.18.126
       '@types/pg':
         specifier: ^8.6.5
         version: 8.20.0
       '@types/uuid':
         specifier: ^8.3.1
         version: 8.3.4
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^5.40.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/parser':
-        specifier: ^5.40.0
-        version: 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      cpx-fixed:
-        specifier: ^1.6.0
-        version: 1.6.0
-      eslint:
-        specifier: ^8.25.0
-        version: 8.57.1
-      eslint-config-prettier:
-        specifier: ^8.5.0
-        version: 8.10.2(eslint@8.57.1)
       glob:
         specifier: ^8.0.3
         version: 8.1.0
-      jest:
-        specifier: ^28.1.2
-        version: 28.1.3(@types/node@16.18.126)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5))
-      prettier:
-        specifier: ^2.3.2
-        version: 2.8.8
-      ts-node:
-        specifier: ^10.7.0
-        version: 10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5)
-      typescript:
-        specifier: ^4.7.4
-        version: 4.9.5
 
   packages/core-persistence:
     dependencies:
@@ -111,33 +111,9 @@ importers:
         specifier: 4.26.1
         version: 4.26.1
     devDependencies:
-      '@types/jest':
-        specifier: ^27.0.1
-        version: 27.5.2
-      '@types/node':
-        specifier: ^16.7.10
-        version: 16.18.126
       '@types/uuid':
         specifier: ^8.3.1
         version: 8.3.4
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^5.40.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/parser':
-        specifier: ^5.40.0
-        version: 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      cpx-fixed:
-        specifier: ^1.6.0
-        version: 1.6.0
-      jest:
-        specifier: ^28.1.2
-        version: 28.1.3(@types/node@16.18.126)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5))
-      prettier:
-        specifier: ^2.3.2
-        version: 2.8.8
-      typescript:
-        specifier: ^4.7.4
-        version: 4.9.5
 
   packages/core-pg:
     dependencies:
@@ -169,33 +145,9 @@ importers:
         specifier: 4.26.1
         version: 4.26.1
     devDependencies:
-      '@types/jest':
-        specifier: ^27.0.1
-        version: 27.5.2
-      '@types/node':
-        specifier: ^16.7.10
-        version: 16.18.126
       '@types/pg':
         specifier: ^8.6.5
         version: 8.20.0
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^5.40.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/parser':
-        specifier: ^5.40.0
-        version: 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      cpx-fixed:
-        specifier: ^1.6.0
-        version: 1.6.0
-      jest:
-        specifier: ^28.1.2
-        version: 28.1.3(@types/node@16.18.126)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5))
-      prettier:
-        specifier: ^2.3.2
-        version: 2.8.8
-      typescript:
-        specifier: ^4.7.4
-        version: 4.9.5
 
   packages/core-pglite:
     dependencies:
@@ -211,43 +163,6 @@ importers:
       node-pg-migrate:
         specifier: ^6.2.1
         version: 6.2.2(pg@8.20.0)
-    devDependencies:
-      '@swc/cli':
-        specifier: ^0.1.57
-        version: 0.1.65(@swc/core@1.15.24)
-      '@swc/core':
-        specifier: ^1.2.223
-        version: 1.15.24
-      '@swc/jest':
-        specifier: ^0.2.22
-        version: 0.2.39(@swc/core@1.15.24)
-      '@types/jest':
-        specifier: ^27.0.1
-        version: 27.5.2
-      '@types/node':
-        specifier: ^16.7.10
-        version: 16.18.126
-      cpx-fixed:
-        specifier: ^1.6.0
-        version: 1.6.0
-      eslint:
-        specifier: ^8.25.0
-        version: 8.57.1
-      eslint-config-prettier:
-        specifier: ^8.5.0
-        version: 8.10.2(eslint@8.57.1)
-      jest:
-        specifier: ^28.1.2
-        version: 28.1.3(@types/node@16.18.126)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5))
-      prettier:
-        specifier: ^2.3.2
-        version: 2.8.8
-      ts-node:
-        specifier: ^10.7.0
-        version: 10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5)
-      typescript:
-        specifier: ^4.7.4
-        version: 4.9.5
       xstate:
         specifier: 4.26.1
         version: 4.26.1
@@ -260,28 +175,6 @@ importers:
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
-    devDependencies:
-      '@types/jest':
-        specifier: ^27.0.1
-        version: 27.5.2
-      '@types/node':
-        specifier: ^16.7.10
-        version: 16.18.126
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^5.40.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/parser':
-        specifier: ^5.40.0
-        version: 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      jest:
-        specifier: ^28.1.2
-        version: 28.1.3(@types/node@16.18.126)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5))
-      prettier:
-        specifier: ^2.3.2
-        version: 2.8.8
-      typescript:
-        specifier: ^4.7.4
-        version: 4.9.5
 
   packages/digest-pg:
     dependencies:
@@ -310,33 +203,9 @@ importers:
         specifier: ^8.3.2
         version: 8.3.2
     devDependencies:
-      '@types/jest':
-        specifier: ^27.0.1
-        version: 27.5.2
-      '@types/node':
-        specifier: ^16.7.10
-        version: 16.18.126
       '@types/pg':
         specifier: ^8.6.5
         version: 8.20.0
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^5.40.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/parser':
-        specifier: ^5.40.0
-        version: 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      cpx-fixed:
-        specifier: ^1.6.0
-        version: 1.6.0
-      jest:
-        specifier: ^28.1.2
-        version: 28.1.3(@types/node@16.18.126)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5))
-      prettier:
-        specifier: ^2.3.2
-        version: 2.8.8
-      typescript:
-        specifier: ^4.7.4
-        version: 4.9.5
 
   packages/digest-pglite:
     dependencies:
@@ -352,43 +221,6 @@ importers:
       node-pg-migrate:
         specifier: ^6.2.1
         version: 6.2.2(pg@8.20.0)
-    devDependencies:
-      '@swc/cli':
-        specifier: ^0.1.57
-        version: 0.1.65(@swc/core@1.15.24)
-      '@swc/core':
-        specifier: ^1.2.223
-        version: 1.15.24
-      '@swc/jest':
-        specifier: ^0.2.22
-        version: 0.2.39(@swc/core@1.15.24)
-      '@types/jest':
-        specifier: ^27.0.1
-        version: 27.5.2
-      '@types/node':
-        specifier: ^16.7.10
-        version: 16.18.126
-      cpx-fixed:
-        specifier: ^1.6.0
-        version: 1.6.0
-      eslint:
-        specifier: ^8.25.0
-        version: 8.57.1
-      eslint-config-prettier:
-        specifier: ^8.5.0
-        version: 8.10.2(eslint@8.57.1)
-      jest:
-        specifier: ^28.1.2
-        version: 28.1.3(@types/node@16.18.126)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5))
-      prettier:
-        specifier: ^2.3.2
-        version: 2.8.8
-      ts-node:
-        specifier: ^10.7.0
-        version: 10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5)
-      typescript:
-        specifier: ^4.7.4
-        version: 4.9.5
 
   packages/digest-reader:
     dependencies:
@@ -401,31 +233,6 @@ importers:
       rxjs:
         specifier: ^7.8.2
         version: 7.8.2
-    devDependencies:
-      '@types/jest':
-        specifier: ^27.0.1
-        version: 27.5.2
-      '@types/node':
-        specifier: ^16.7.10
-        version: 16.18.126
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^5.40.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/parser':
-        specifier: ^5.40.0
-        version: 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      cpx-fixed:
-        specifier: ^1.6.0
-        version: 1.6.0
-      jest:
-        specifier: ^28.1.2
-        version: 28.1.3(@types/node@16.18.126)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5))
-      prettier:
-        specifier: ^2.3.2
-        version: 2.8.8
-      typescript:
-        specifier: ^4.7.4
-        version: 4.9.5
 
   packages/digest-writer:
     dependencies:
@@ -451,33 +258,9 @@ importers:
         specifier: ^8.3.2
         version: 8.3.2
     devDependencies:
-      '@types/jest':
-        specifier: ^27.0.1
-        version: 27.5.2
-      '@types/node':
-        specifier: ^16.7.10
-        version: 16.18.126
       '@types/pg':
         specifier: ^8.6.5
         version: 8.20.0
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^5.40.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/parser':
-        specifier: ^5.40.0
-        version: 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      cpx-fixed:
-        specifier: ^1.6.0
-        version: 1.6.0
-      jest:
-        specifier: ^28.1.2
-        version: 28.1.3(@types/node@16.18.126)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5))
-      prettier:
-        specifier: ^2.3.2
-        version: 2.8.8
-      typescript:
-        specifier: ^4.7.4
-        version: 4.9.5
 
   packages/journal-persistence:
     dependencies:
@@ -496,31 +279,6 @@ importers:
       xstate:
         specifier: 4.26.1
         version: 4.26.1
-    devDependencies:
-      '@types/jest':
-        specifier: ^27.0.1
-        version: 27.5.2
-      '@types/node':
-        specifier: ^16.7.10
-        version: 16.18.126
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^5.40.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/parser':
-        specifier: ^5.40.0
-        version: 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      cpx-fixed:
-        specifier: ^1.6.0
-        version: 1.6.0
-      jest:
-        specifier: ^28.1.2
-        version: 28.1.3(@types/node@16.18.126)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5))
-      prettier:
-        specifier: ^2.3.2
-        version: 2.8.8
-      typescript:
-        specifier: ^4.7.4
-        version: 4.9.5
 
   packages/journal-pg:
     dependencies:
@@ -552,33 +310,9 @@ importers:
         specifier: ^8.3.2
         version: 8.3.2
     devDependencies:
-      '@types/jest':
-        specifier: ^27.0.1
-        version: 27.5.2
-      '@types/node':
-        specifier: ^16.7.10
-        version: 16.18.126
       '@types/pg':
         specifier: ^8.6.5
         version: 8.20.0
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^5.40.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/parser':
-        specifier: ^5.40.0
-        version: 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      cpx-fixed:
-        specifier: ^1.6.0
-        version: 1.6.0
-      jest:
-        specifier: ^28.1.2
-        version: 28.1.3(@types/node@16.18.126)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5))
-      prettier:
-        specifier: ^2.3.2
-        version: 2.8.8
-      typescript:
-        specifier: ^4.7.4
-        version: 4.9.5
 
   packages/journal-pglite:
     dependencies:
@@ -597,31 +331,6 @@ importers:
       xstate:
         specifier: 4.26.1
         version: 4.26.1
-    devDependencies:
-      '@types/node':
-        specifier: ^16.7.10
-        version: 16.18.126
-      cpx-fixed:
-        specifier: ^1.6.0
-        version: 1.6.0
-      eslint:
-        specifier: ^8.25.0
-        version: 8.57.1
-      eslint-config-prettier:
-        specifier: ^8.5.0
-        version: 8.10.2(eslint@8.57.1)
-      jest:
-        specifier: ^28.1.2
-        version: 28.1.3(@types/node@16.18.126)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5))
-      prettier:
-        specifier: ^2.3.2
-        version: 2.8.8
-      ts-node:
-        specifier: ^10.7.0
-        version: 10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5)
-      typescript:
-        specifier: ^4.7.4
-        version: 4.9.5
 
   packages/journal-reader:
     dependencies:
@@ -656,33 +365,9 @@ importers:
         specifier: 4.26.1
         version: 4.26.1
     devDependencies:
-      '@types/jest':
-        specifier: ^27.0.1
-        version: 27.5.2
-      '@types/node':
-        specifier: ^16.7.10
-        version: 16.18.126
       '@types/pg':
         specifier: ^8.6.5
         version: 8.20.0
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^5.40.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/parser':
-        specifier: ^5.40.0
-        version: 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      cpx-fixed:
-        specifier: ^1.6.0
-        version: 1.6.0
-      jest:
-        specifier: ^28.1.2
-        version: 28.1.3(@types/node@16.18.126)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5))
-      prettier:
-        specifier: ^2.3.2
-        version: 2.8.8
-      typescript:
-        specifier: ^4.7.4
-        version: 4.9.5
 
   packages/journal-writer:
     dependencies:
@@ -695,28 +380,6 @@ importers:
       '@samihult/xjog-util':
         specifier: workspace:^
         version: link:../util
-    devDependencies:
-      '@types/jest':
-        specifier: ^27.0.1
-        version: 27.5.2
-      '@types/node':
-        specifier: ^16.7.10
-        version: 16.18.126
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^5.40.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/parser':
-        specifier: ^5.40.0
-        version: 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      jest:
-        specifier: ^28.1.2
-        version: 28.1.3(@types/node@16.18.126)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5))
-      prettier:
-        specifier: ^2.3.2
-        version: 2.8.8
-      typescript:
-        specifier: ^4.7.4
-        version: 4.9.5
 
   packages/util:
     dependencies:
@@ -726,28 +389,6 @@ importers:
       xstate:
         specifier: 4.26.1
         version: 4.26.1
-    devDependencies:
-      '@types/jest':
-        specifier: ^27.0.1
-        version: 27.5.2
-      '@types/node':
-        specifier: ^16.7.10
-        version: 16.18.126
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^5.40.0
-        version: 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@4.9.5))(eslint@8.57.1)(typescript@4.9.5)
-      '@typescript-eslint/parser':
-        specifier: ^5.40.0
-        version: 5.62.0(eslint@8.57.1)(typescript@4.9.5)
-      jest:
-        specifier: ^28.1.2
-        version: 28.1.3(@types/node@16.18.126)(ts-node@10.9.2(@swc/core@1.15.24)(@types/node@16.18.126)(typescript@4.9.5))
-      prettier:
-        specifier: ^2.3.2
-        version: 2.8.8
-      typescript:
-        specifier: ^4.7.4
-        version: 4.9.5
 
 packages:
 
@@ -4778,10 +4419,12 @@ snapshots:
 
   '@hutson/parse-repository-url@3.0.2': {}
 
-  '@inquirer/external-editor@1.0.3':
+  '@inquirer/external-editor@1.0.3(@types/node@16.18.126)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
+    optionalDependencies:
+      '@types/node': 16.18.126
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -5021,7 +4664,7 @@ snapshots:
       execa: 5.0.0
       strong-log-transformer: 2.1.0
 
-  '@lerna/create@7.4.2(@swc/core@1.15.24)(encoding@0.1.13)(typescript@4.9.5)':
+  '@lerna/create@7.4.2(@swc/core@1.15.24)(@types/node@16.18.126)(encoding@0.1.13)(typescript@4.9.5)':
     dependencies:
       '@lerna/child-process': 7.4.2
       '@npmcli/run-script': 6.0.2
@@ -5047,7 +4690,7 @@ snapshots:
       has-unicode: 2.0.1
       ini: 1.3.8
       init-package-json: 5.0.0
-      inquirer: 8.2.7
+      inquirer: 8.2.7(@types/node@16.18.126)
       is-ci: 3.0.1
       is-stream: 2.0.0
       js-yaml: 4.1.0
@@ -6911,9 +6554,9 @@ snapshots:
       validate-npm-package-license: 3.0.4
       validate-npm-package-name: 5.0.0
 
-  inquirer@8.2.7:
+  inquirer@8.2.7(@types/node@16.18.126):
     dependencies:
-      '@inquirer/external-editor': 1.0.3
+      '@inquirer/external-editor': 1.0.3(@types/node@16.18.126)
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       cli-cursor: 3.1.0
@@ -7431,10 +7074,10 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  lerna@7.4.2(@swc/core@1.15.24)(encoding@0.1.13):
+  lerna@7.4.2(@swc/core@1.15.24)(@types/node@16.18.126)(encoding@0.1.13):
     dependencies:
       '@lerna/child-process': 7.4.2
-      '@lerna/create': 7.4.2(@swc/core@1.15.24)(encoding@0.1.13)(typescript@4.9.5)
+      '@lerna/create': 7.4.2(@swc/core@1.15.24)(@types/node@16.18.126)(encoding@0.1.13)(typescript@4.9.5)
       '@npmcli/run-script': 6.0.2
       '@nx/devkit': 16.10.0(nx@16.10.0(@swc/core@1.15.24))
       '@octokit/plugin-enterprise-rest': 6.0.1
@@ -7462,7 +7105,7 @@ snapshots:
       import-local: 3.1.0
       ini: 1.3.8
       init-package-json: 5.0.0
-      inquirer: 8.2.7
+      inquirer: 8.2.7(@types/node@16.18.126)
       is-ci: 3.0.1
       is-stream: 2.0.0
       jest-diff: 29.7.0


### PR DESCRIPTION
## Summary
- move shared build, lint, test, and formatting tool dependencies to the workspace root
- update package scripts to use `pnpm exec` so tools resolve reliably from the root under pnpm and Nx
- keep package-local manifests focused on runtime deps and package-specific typing deps, while fixing `core-pglite` to declare `xstate` as a runtime dependency

## Verification
- `pnpm install`
- `pnpm lerna run build`
- `pnpm lerna run lint`
- `pnpm lerna run test`