### PR TITLE
Fix overlapping takeUpcomingDeferredEvents

### DIFF
--- a/packages/core/src/XJogDeferredEventManager.test.ts
+++ b/packages/core/src/XJogDeferredEventManager.test.ts
@@ -437,4 +437,71 @@ describe('XJogDeferredEventManager', () => {
       await deferredEventManager.releaseAll();
     }
   });
+
+  it('does not overlap takeUpcomingDeferredEvents when scheduleUpcoming is called concurrently', async () => {
+    let inFlightReads = 0;
+    let maxInFlightReads = 0;
+    let resolveFirstRead: (() => void) | undefined;
+    let notifyFirstReadStarted: (() => void) | undefined;
+
+    const firstReadStarted = new Promise<void>((resolve) => {
+      notifyFirstReadStarted = resolve;
+    });
+    const firstReadCanFinish = new Promise<void>((resolve) => {
+      resolveFirstRead = resolve;
+    });
+
+    const persistence = {
+      deferEvent: jest.fn(),
+      takeUpcomingDeferredEvents: jest.fn(async () => {
+        inFlightReads += 1;
+        maxInFlightReads = Math.max(maxInFlightReads, inFlightReads);
+
+        try {
+          if (notifyFirstReadStarted) {
+            notifyFirstReadStarted();
+            notifyFirstReadStarted = undefined;
+            await firstReadCanFinish;
+          }
+
+          return [];
+        } finally {
+          inFlightReads -= 1;
+        }
+      }),
+      removeDeferredEvent: jest.fn(),
+      releaseAllDeferredEvents: jest.fn(),
+    } as unknown as PersistenceAdapter;
+
+    const [xJog, deferredEventManager] = mockXJogWithDeferredEventManager(
+      persistence,
+      {
+        batchSize: 5,
+        lookAhead: 1000,
+        interval: 1000,
+      },
+    );
+
+    try {
+      const firstSchedule = deferredEventManager.scheduleUpcoming();
+      await firstReadStarted;
+
+      await deferredEventManager.scheduleUpcoming();
+
+      expect(persistence.takeUpcomingDeferredEvents).toHaveBeenCalledTimes(1);
+      expect(maxInFlightReads).toBe(1);
+
+      resolveFirstRead!();
+      await firstSchedule;
+
+      await waitFor(25);
+
+      expect(persistence.takeUpcomingDeferredEvents).toHaveBeenCalledTimes(2);
+      expect(maxInFlightReads).toBe(1);
+    } finally {
+      // @ts-ignore test-only shutdown flag
+      xJog.dying = true;
+      await deferredEventManager.releaseAll();
+    }
+  });
 });

--- a/packages/core/src/XJogDeferredEventManager.ts
+++ b/packages/core/src/XJogDeferredEventManager.ts
@@ -39,6 +39,13 @@ export class XJogDeferredEventManager {
    */
   private deferredEventTimers = new Map<string | number, NodeJS.Timeout>();
 
+  /**
+   * Guard against concurrent scheduleUpcoming executions which can cause
+   * deadlocks when two readDeferredEventRowBatch queries overlap.
+   */
+  private scheduling = false;
+  private rescheduleRequestedDuring = false;
+
   public constructor(private readonly xJog: XJog) {
     this.options = xJog.options.deferredEvents;
   }
@@ -179,54 +186,80 @@ export class XJogDeferredEventManager {
         ...args,
       });
 
-    this.deferredEventHandlerTimer = null;
-    this.nextReadAt = Number.MAX_SAFE_INTEGER;
-
-    // If dying, don't schedule anything new
-    if (this.xJog.dying) {
-      trace({ message: 'Stopping deferred event scheduling because dying' });
+    // Prevent concurrent execution — two overlapping readDeferredEventRowBatch
+    // CTE queries can deadlock when they try to UPDATE the same rows in
+    // different physical order.
+    if (this.scheduling) {
+      trace({ message: 'Already scheduling, deferring to current run' });
+      this.rescheduleRequestedDuring = true;
       return;
     }
 
-    trace({ message: 'Taking a batch of upcoming events' });
-    const deferredEvents: PersistedDeferredEvent[] =
-      await this.xJog.persistence.takeUpcomingDeferredEvents(
-        this.xJog.id,
-        this.options.lookAhead,
-        this.options.batchSize,
-        cid,
-      );
-    trace({ message: 'Batch of events taken', count: deferredEvents.length });
+    this.scheduling = true;
+    this.rescheduleRequestedDuring = false;
 
-    for (const PersistedDeferredEvent of deferredEvents) {
-      this.schedule(PersistedDeferredEvent, cid);
-    }
+    try {
+      this.deferredEventHandlerTimer = null;
+      this.nextReadAt = Number.MAX_SAFE_INTEGER;
 
-    // If the batch size matches with the read batch, there are probably more
-    // coming up. Schedule next read right after this batches last item.
-    if (deferredEvents.length === this.options.batchSize) {
-      const lastDeferredEvent = deferredEvents[deferredEvents.length - 1];
-      if (lastDeferredEvent) {
-        trace({
-          message:
-            'Scheduling next read after the due time of the last deferred event',
-          at: lastDeferredEvent,
-        });
-        this.rescheduleNextReadNoLaterThan(lastDeferredEvent.due);
-      } else {
-        trace({ message: 'Scheduling next read immediately' });
-        this.rescheduleNextReadNoLaterThan(Date.now());
+      // If dying, don't schedule anything new
+      if (this.xJog.dying) {
+        trace({ message: 'Stopping deferred event scheduling because dying' });
+        return;
       }
-    }
 
-    // If we read less items than the batch size, there are no items to be
-    // expected during the read interval. Schedule a regular read after that.
-    else {
-      this.rescheduleNextReadNoLaterThan(Date.now() + this.options.interval);
-      trace({
-        message: 'Scheduling next read after the regular interval',
-        after: this.options.interval,
-      });
+      trace({ message: 'Taking a batch of upcoming events' });
+      const deferredEvents: PersistedDeferredEvent[] =
+        await this.xJog.persistence.takeUpcomingDeferredEvents(
+          this.xJog.id,
+          this.options.lookAhead,
+          this.options.batchSize,
+          cid,
+        );
+      trace({ message: 'Batch of events taken', count: deferredEvents.length });
+
+      for (const PersistedDeferredEvent of deferredEvents) {
+        this.schedule(PersistedDeferredEvent, cid);
+      }
+
+      // If the batch size matches with the read batch, there are probably more
+      // coming up. Schedule next read right after this batches last item.
+      if (deferredEvents.length === this.options.batchSize) {
+        const lastDeferredEvent = deferredEvents[deferredEvents.length - 1];
+        if (lastDeferredEvent) {
+          trace({
+            message:
+              'Scheduling next read after the due time of the last deferred event',
+            at: lastDeferredEvent,
+          });
+          this.rescheduleNextReadNoLaterThan(lastDeferredEvent.due);
+        } else {
+          trace({ message: 'Scheduling next read immediately' });
+          this.rescheduleNextReadNoLaterThan(Date.now());
+        }
+      }
+
+      // If we read less items than the batch size, there are no items to be
+      // expected during the read interval. Schedule a regular read after that.
+      else {
+        this.rescheduleNextReadNoLaterThan(Date.now() + this.options.interval);
+        trace({
+          message: 'Scheduling next read after the regular interval',
+          after: this.options.interval,
+        });
+      }
+    } finally {
+      this.scheduling = false;
+
+      // A defer() call during execution requested a reschedule — honour it now.
+      // Use rescheduleNextReadAt (not NoLaterThan) because the timer handle from
+      // the blocked call is stale (already fired) but non-null, which would cause
+      // rescheduleNextReadNoLaterThan to skip scheduling.
+      if (this.rescheduleRequestedDuring) {
+        this.rescheduleRequestedDuring = false;
+        trace({ message: 'Rescheduling after deferred request during run' });
+        this.rescheduleNextReadAt(Date.now());
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- prevent overlapping `scheduleUpcoming()` runs in `XJogDeferredEventManager`
- avoid concurrent `takeUpcomingDeferredEvents` reads that can deadlock when they update the same deferred-event rows in different order
- add a regression test covering concurrent scheduling calls

## Details

`XJogDeferredEventManager.scheduleUpcoming()` could be entered concurrently, which allowed multiple `takeUpcomingDeferredEvents()` queries to run at the same time. In practice, overlapping reads against the same deferred events could deadlock.
This change adds an internal scheduling guard so only one scheduling pass can execute at a time. If another scheduling request arrives while one is already running, it is recorded and replayed immediately after the active run completes.

## Testing

- added a regression test verifying concurrent `scheduleUpcoming()` calls do not overlap
- verified the deferred event manager reschedules once the in-flight read completes