### PR TITLE
fix: run runStep on adopted charts even when skipRunningActionsOnRehydrate=true

### DIFF
--- a/packages/core/src/XJogStartupManager.test.ts
+++ b/packages/core/src/XJogStartupManager.test.ts
@@ -122,3 +122,46 @@ describe('XJogStartupManager: grace period timer must not reset on every cycle',
     clearTimeout(startupManager.adoptionLoopTimer);
   });
 });
+
+describe('XJogStartupManager.startAdoptedCharts: missing-after-timer repair', () => {
+  it('calls runStep on each adopted chart even when skipRunningActionsOnRehydrate=true', async () => {
+    const persistence = await PGlitePersistenceAdapter.connect();
+    const [xJog, startupManager] = mockXJogWithStartupManager(persistence);
+
+    xJog.options.startup.skipRunningActionsOnRehydrate = true;
+
+    const runStep = jest.fn().mockResolvedValue(undefined);
+    (xJog as unknown as { getChart: jest.Mock }).getChart = jest
+      .fn()
+      .mockResolvedValue({ runStep });
+
+    const refs = [
+      { machineId: 'm', chartId: 'c1' },
+      { machineId: 'm', chartId: 'c2' },
+    ];
+
+    // @ts-expect-error Private access
+    await startupManager.startAdoptedCharts(refs);
+
+    expect(runStep).toHaveBeenCalledTimes(refs.length);
+  });
+
+  it('still calls runStep when skipRunningActionsOnRehydrate=false (unchanged behavior)', async () => {
+    const persistence = await PGlitePersistenceAdapter.connect();
+    const [xJog, startupManager] = mockXJogWithStartupManager(persistence);
+
+    xJog.options.startup.skipRunningActionsOnRehydrate = false;
+
+    const runStep = jest.fn().mockResolvedValue(undefined);
+    (xJog as unknown as { getChart: jest.Mock }).getChart = jest
+      .fn()
+      .mockResolvedValue({ runStep });
+
+    // @ts-expect-error Private access
+    await startupManager.startAdoptedCharts([
+      { machineId: 'm', chartId: 'c1' },
+    ]);
+
+    expect(runStep).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/XJogStartupManager.ts
+++ b/packages/core/src/XJogStartupManager.ts
@@ -218,11 +218,10 @@ export class XJogStartupManager {
     refs: ChartReference[],
     cid = getCorrelationIdentifier(),
   ): Promise<void> {
-    const skipOnRehydrate =
-      this.xJog.options.startup.skipRunningActionsOnRehydrate;
-    if (skipOnRehydrate) {
-      return;
-    }
+    // runStep internally honors skipRunningActionsOnRehydrate — when the flag
+    // is set, it skips persisted state.actions but still executes reconstructed
+    // missing xstate.after(...) send actions, so stuck polling timers self-heal
+    // on adoption without replaying history.
     for (const ref of refs) {
       const adoptedChart = await this.xJog.getChart(ref, cid);
       await adoptedChart?.runStep(cid);


### PR DESCRIPTION
## Summary

`XJogChart.runStep` already honors `skipRunningActionsOnRehydrate` internally: when the flag is set, persisted `state.actions` are skipped but reconstructed `xstate.after(...)` send actions from `resolveMissingAfterActions` still run. The outer early-return in `XJogStartupManager.startAdoptedCharts` bypassed `runStep` entirely when the flag was set, which made the missing-after-timer repair dead code under the flag.

In production (ecommerce checkout-controller), all four environments (`local`/`dev`/`staging`/`prod`) set `skipRunningActionsOnRehydrate: true`. So every restart was silently skipping the repair of charts with missing `xstate.after(...)` deferred-event rows. Real-world impact: 12+ charts stuck in `claudia status polling.waiting` with no polling timer row, discovered during the 17 April 2026 dev test run.

The fix is one removed block: let `runStep` run for every adopted chart. Its body does the right thing for both values of the flag.

## Change

`packages/core/src/XJogStartupManager.ts` — `startAdoptedCharts` no longer early-returns on `skipRunningActionsOnRehydrate`. Replaced with a four-line comment pointing at the collaborating conditional in `XJogChart.runStep`.

## Tests

Two new cases in `packages/core/src/XJogStartupManager.test.ts`:
- `calls runStep on each adopted chart even when skipRunningActionsOnRehydrate=true` — previously failed (0 calls), now passes.
- `still calls runStep when skipRunningActionsOnRehydrate=false (unchanged behavior)` — no-regression guard.

Both stub `runStep` via a mocked `getChart` and assert call counts matching `refs.length`.

### Verification

- `cd packages/core && pnpm test` — 25 passed, 3 skipped (unchanged).
- `pnpm -w exec lerna run build --since=upstream` — green.
- TDD gate independently reproduced: stashing the source change flips the \`=true\` test red with \`Received 0\`; restoring makes it green.

## Related

- EAT-64371
- Telia ecommerce companion plan: \`docs/superpowers/plans/2026-04-20-xjog-repair-missing-timers-on-rehydrate.md\`