### PR TITLE
fix: don't leak unhandled rejections from activity-manager subscriber

### DIFF
--- a/packages/core/src/XJogActivityManager.test.ts
+++ b/packages/core/src/XJogActivityManager.test.ts
@@ -88,4 +88,60 @@ describe('XJogActivityManager', () => {
 
     expect(activity.send).toHaveBeenCalledWith('test event');
   });
+
+  // Regression: when an invoked promise's actor surfaces a rejection through
+  // the activity-manager subscriber, the manager dispatches an
+  // `error.platform.<id>` event via `xJog.sendEvent(...)`. That call returns
+  // a promise. Before the fix the promise was fire-and-forget — if it
+  // rejected (e.g. the parent chart had just been torn down or its onError
+  // action threw during dispatch) the rejection escaped to
+  // `process.unhandledRejection`. In production this killed the pod via the
+  // process-level handler. The same shape applies to `next` (defer) and
+  // `complete` (stopActivity).
+  it('Does not leak unhandled rejections from sendEvent in the activity error subscriber', async () => {
+    const persistence = await PGlitePersistenceAdapter.connect();
+    const [xJog, activityManager] = mockXJogWithActivityManager(persistence);
+
+    let captured: any = null;
+    const activity = {
+      id: 'activity-id',
+      owner: { machineId: 'machine-id', chartId: 'chart-id' },
+      toJSON: jest.fn(() => ({ id: 'activity-id' })),
+      send: jest.fn(),
+      subscribe: jest.fn((subscriber: any) => {
+        captured = subscriber;
+        return jest.fn();
+      }),
+      stop: jest.fn(),
+    } as unknown as ActivityRef;
+
+    (xJog.sendEvent as jest.Mock).mockRejectedValue(
+      new Error('Synthetic sendEvent failure'),
+    );
+
+    const unhandled: unknown[] = [];
+    const handler = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', handler);
+
+    try {
+      await activityManager.registerActivity(activity);
+      expect(captured).not.toBeNull();
+
+      // Mimic what XJogChart.spawnPromise does on rejection: invoke the
+      // subscriber's error callback. This synchronously fires-and-forgets
+      // `xJog.sendEvent(...)`.
+      captured.error(new Error('Activity rejected'));
+
+      // Yield enough microtasks for the rejected sendEvent promise to be
+      // observed as unhandled if no .catch was attached.
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(xJog.sendEvent).toHaveBeenCalled();
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', handler);
+      await activityManager.stopAndUnregisteredActivity(activity);
+    }
+  });
 });

--- a/packages/core/src/XJogActivityManager.ts
+++ b/packages/core/src/XJogActivityManager.ts
@@ -195,14 +195,25 @@ export class XJogActivityManager {
               value,
             });
 
-            this.xJog.deferredEventManager.defer(
-              {
-                ref: activity.owner,
-                delay: 0,
-                event: toSCXMLEvent(value),
-              },
-              cid,
-            );
+            // Fire-and-forget: must not let a rejection escape to
+            // process.unhandledRejection, which would kill the host process.
+            this.xJog.deferredEventManager
+              .defer(
+                {
+                  ref: activity.owner,
+                  delay: 0,
+                  event: toSCXMLEvent(value),
+                },
+                cid,
+              )
+              .catch((err) => {
+                trace({
+                  level: 'error',
+                  in: 'activityManager.subscriber',
+                  message: 'Failed to defer event from activity',
+                  err,
+                });
+              });
           }
         },
 
@@ -221,10 +232,18 @@ export class XJogActivityManager {
               error,
             });
 
-            this.xJog.sendEvent(
-              activity.owner,
-              actions.error(activity.id, error),
-            );
+            // Fire-and-forget: must not let a rejection escape to
+            // process.unhandledRejection, which would kill the host process.
+            this.xJog
+              .sendEvent(activity.owner, actions.error(activity.id, error))
+              .catch((err) => {
+                trace({
+                  level: 'error',
+                  in: 'activityManager.subscriber',
+                  message: 'Failed to send error event from activity',
+                  err,
+                });
+              });
           }
         },
 
@@ -240,7 +259,16 @@ export class XJogActivityManager {
               message: 'Stopping activity',
             });
 
-            this.stopActivity(activity.owner, activity.id);
+            // Fire-and-forget: must not let a rejection escape to
+            // process.unhandledRejection, which would kill the host process.
+            this.stopActivity(activity.owner, activity.id).catch((err) => {
+              trace({
+                level: 'error',
+                in: 'activityManager.subscriber',
+                message: 'Failed to stop activity on completion',
+                err,
+              });
+            });
           }
         },
       });


### PR DESCRIPTION
## Summary

\`XJogActivityManager.registerActivity\` attaches a subscriber to each spawned activity. The three subscriber callbacks each kicked off async work but never awaited or \`.catch()\`-ed it:

| callback | call | what it returns |
|----------|------|-----------------|
| \`next\` | \`deferredEventManager.defer(...)\` | \`Promise<void>\` |
| \`error\` | \`xJog.sendEvent(owner, error.platform.<id>)\` | \`Promise<State \| null>\` |
| \`complete\` | \`stopActivity(owner, id)\` | \`Promise<void>\` |

When any of those returned promises rejected — e.g. the parent chart had just been torn down (so \`getChart\` returned null and a downstream cast failed), or its \`onError\` action threw during dispatch — the rejection escaped to \`process.unhandledRejection\`. Hosts that re-throw on \`unhandledRejection\` (Node's default since v15, and an explicit pattern in some downstream services) crashed the entire process for what should have been a per-chart failure.

This is what we observed in production for one of our services: four identical promise rejections in ~1.2s; three were absorbed normally via the chart's \`onError\` transition; the fourth raced a transition or chart teardown such that \`sendEvent\` itself rejected, and that fire-and-forget rejection killed the pod.

## Fix

Each call site now attaches a \`.catch()\` that logs at error level via the existing \`trace\` channel and otherwise swallows the rejection. The activity-manager subscriber is the wrong layer to surface persistence or transition failures — those should be handled inside the chart they belong to. Isolating one chart's failure from the host process is the desired blast radius.

## Test

Includes a regression test in \`XJogActivityManager.test.ts\` that mocks \`xJog.sendEvent\` to reject and exercises the subscriber's error path directly. On the prior code, jest reports the unhandled rejection and the test fails with the synthetic error. With the fix, jest sees no unhandled rejections and the test passes.

\`\`\`
✓ Does not leak unhandled rejections from sendEvent in the activity error subscriber
\`\`\`

The same shape applies to \`next\` (\`defer\`) and \`complete\` (\`stopActivity\`); only the \`error\` path is covered by the test, since that's the one we observed in production. Adding tests for the other two would follow the same pattern but require mocking \`deferredEventManager\`/\`stopActivity\` rejections, which seems overkill given the fix is symmetric across all three.

## Out of scope

- We could also add defensive try/catch around the \`observer.next\`/\`observer.error\`/\`observer.complete\` calls inside \`XJogChart.spawnPromise\`, but with this fix in place those observer methods (which are this subscriber's body) no longer throw synchronously, so the spawnPromise side stays clean. Happy to do that here too if you'd prefer belt-and-braces.
- The same fire-and-forget pattern likely exists in other parts of the codebase; \`grep -nE 'this\\.xJog\\.\\w+\\(' packages/core/src/*.ts | grep -v 'await\\|return\\|=\\|throw'\` would surface candidates. Not in scope here — opening this PR with the minimal observed-incident fix.