### PR TITLE
fix: await queries sequentially in journal-pg notification handler

### DIFF
--- a/packages/journal-pg/src/PostgresJournalPersistenceAdapter.ts
+++ b/packages/journal-pg/src/PostgresJournalPersistenceAdapter.ts
@@ -370,25 +370,23 @@ export class PostgresJournalPersistenceAdapter extends JournalPersistenceAdapter
 
     // Received a notification of a new journal entry
     journalSubscriber.notifications.on(channel, async () => {
-      this.queryEntries({
+      const journalEntries = await this.queryEntries({
         afterId: journalEntryIdPointer,
         updatedAfterAndIncluding: startTime,
         order: 'DESC',
-      }).then((journalEntries: JournalEntry[]) => {
-        if (journalEntries.length) {
-          yieldJournalEntries(journalEntries);
-        }
       });
+      if (journalEntries.length) {
+        yieldJournalEntries(journalEntries);
+      }
 
-      this.queryFullStates({
+      const fullStateEntries = await this.queryFullStates({
         afterId: fullStateEntryIdPointer,
         updatedAfterAndIncluding: startTime,
         order: 'DESC',
-      }).then((fullStateEntries: FullStateEntry[]) => {
-        if (fullStateEntries.length) {
-          yieldFullStateEntries(fullStateEntries);
-        }
       });
+      if (fullStateEntries.length) {
+        yieldFullStateEntries(fullStateEntries);
+      }
     });
 
     journalSubscriber.events.on('error', (error) => {


### PR DESCRIPTION
## Problem

The LISTEN/NOTIFY handler in `PostgresJournalPersistenceAdapter` was calling `queryEntries()` and `queryFullStates()` concurrently on the same `readConnection` pg.Client:

```ts
journalSubscriber.notifications.on(channel, async () => {
  this.queryEntries({ ... }).then(...);   // fires readConnection.query()
  this.queryFullStates({ ... }).then(...)  // fires readConnection.query() concurrently
});
```

A `pg.Client` is single-pipeline and cannot handle concurrent queries. pg@8 emits a `DeprecationWarning` for this; pg@9 will throw.

## Fix

Await each query in sequence inside the `async` handler:

```ts
journalSubscriber.notifications.on(channel, async () => {
  const journalEntries = await this.queryEntries({ ... });
  if (journalEntries.length) yieldJournalEntries(journalEntries);

  const fullStateEntries = await this.queryFullStates({ ... });
  if (fullStateEntries.length) yieldFullStateEntries(fullStateEntries);
});
```

The handler was already `async` — it just wasn't using it.