### PR TITLE
fix(core): stop XJog.shutdown() hanging by deregistering the departing instance

### DIFF
--- a/packages/core-persistence/src/PersistenceAdapter.ts
+++ b/packages/core-persistence/src/PersistenceAdapter.ts
@@ -15,9 +15,11 @@ import {
 import type { PersistedChart, PersistedDeferredEvent } from './EntryTypes';
 
 /**
- * How long an instance row may stay marked `dying` before it is reaped on the
- * next startup. Long enough that a dying instance still shutting down is never
- * removed out from under itself, short enough to bound `instances` growth.
+ * How long an instance row may stay marked `dying` (measured from when it
+ * entered the dying state, which `markInstanceDying`/`markAllInstancesDying`
+ * stamp onto `timestamp`) before it is reaped on the next startup. Long enough
+ * that an instance just overthrown still sees its own death note and shuts
+ * down before its row disappears, short enough to bound `instances` growth.
  */
 export const DEAD_INSTANCE_RETENTION_MS = 60 * 60 * 1000;
 

--- a/packages/core-persistence/src/PersistenceAdapter.ts
+++ b/packages/core-persistence/src/PersistenceAdapter.ts
@@ -15,6 +15,13 @@ import {
 import type { PersistedChart, PersistedDeferredEvent } from './EntryTypes';
 
 /**
+ * How long an instance row may stay marked `dying` before it is reaped on the
+ * next startup. Long enough that a dying instance still shutting down is never
+ * removed out from under itself, short enough to bound `instances` growth.
+ */
+export const DEAD_INSTANCE_RETENTION_MS = 60 * 60 * 1000;
+
+/**
  * Abstract adapter class for XJog persistence.
  * @hideconstructor
  */
@@ -50,10 +57,26 @@ export abstract class PersistenceAdapter<
   ): Promise<void>;
 
   /**
+   * Mark a single instance as dying so it stops counting as alive
+   * ({@link countAliveInstances} excludes `dying=TRUE` rows). Used on graceful
+   * shutdown to deregister the departing instance.
+   *
    * @abstract
    */
-  protected abstract deleteInstance(
+  protected abstract markInstanceDying(
     id: string,
+    connection?: ConnectionType,
+  ): Promise<void>;
+
+  /**
+   * Delete instance rows that have been marked dying for longer than
+   * `retentionMs`. Bounds growth of the `instances` table and lets rows left
+   * behind by killed processes age out. Never touches `dying=FALSE` rows.
+   *
+   * @abstract
+   */
+  protected abstract reapDeadInstances(
+    retentionMs: number,
     connection?: ConnectionType,
   ): Promise<void>;
 
@@ -377,6 +400,12 @@ export abstract class PersistenceAdapter<
 
       trace({ message: 'Adding the instance to the list' });
       await this.insertInstance(instanceId, connection);
+
+      // Reap instance rows that have been dying past the retention window.
+      // These are left behind by graceful shutdowns and by processes killed
+      // without one; without this the table grows one row per process start.
+      trace({ message: 'Reaping long-dead instances' });
+      await this.reapDeadInstances(DEAD_INSTANCE_RETENTION_MS, connection);
     });
 
     trace({ message: 'Done' });
@@ -386,7 +415,11 @@ export abstract class PersistenceAdapter<
     const trace = (args: Record<string, any>) =>
       this.trace({ cid, in: 'removeInstance', ...args });
 
-    await this.deleteInstance(instanceId);
+    // Deregister this instance so it stops counting as alive. Marking it dying
+    // (rather than deleting the row) keeps it consistent with the death-note
+    // model and lets countAliveInstances exclude it for free. The row is reaped
+    // later by reapDeadInstances on a subsequent startup.
+    await this.markInstanceDying(instanceId);
 
     trace({ message: 'Done' });
   }

--- a/packages/core-pg/src/PostgresPersistenceAdapter.ts
+++ b/packages/core-pg/src/PostgresPersistenceAdapter.ts
@@ -169,12 +169,27 @@ export class PostgresPersistenceAdapter extends PersistenceAdapter<PoolClient> {
     );
   }
 
-  protected async deleteInstance(
+  protected async markInstanceDying(
     id: string,
     connection: Pool | PoolClient = this.pool,
   ): Promise<void> {
-    // TODO re-enable or make a cleanup with some lookbehind period
-    // await connection.query('DELETE FROM instances WHERE "instanceId"=$1', [id]);
+    await connection.query(
+      bind('UPDATE "instances" SET "dying"=TRUE WHERE "instanceId"=:id', { id }),
+    );
+  }
+
+  protected async reapDeadInstances(
+    retentionMs: number,
+    connection: Pool | PoolClient = this.pool,
+  ): Promise<void> {
+    await connection.query(
+      bind(
+        'DELETE FROM "instances" ' +
+          'WHERE "dying"=TRUE ' +
+          'AND "timestamp" < now() - make_interval(secs => :seconds)',
+        { seconds: retentionMs / 1000 },
+      ),
+    );
   }
 
   protected async markAllInstancesDying(

--- a/packages/core-pg/src/PostgresPersistenceAdapter.ts
+++ b/packages/core-pg/src/PostgresPersistenceAdapter.ts
@@ -173,8 +173,15 @@ export class PostgresPersistenceAdapter extends PersistenceAdapter<PoolClient> {
     id: string,
     connection: Pool | PoolClient = this.pool,
   ): Promise<void> {
+    // Refresh "timestamp" so it marks when the row entered the dying state.
+    // reapDeadInstances ages rows out relative to this, so a long-lived
+    // instance is not reaped immediately after a graceful shutdown.
     await connection.query(
-      bind('UPDATE "instances" SET "dying"=TRUE WHERE "instanceId"=:id', { id }),
+      bind(
+        'UPDATE "instances" SET "dying"=TRUE, "timestamp"=now() ' +
+          'WHERE "instanceId"=:id',
+        { id },
+      ),
     );
   }
 
@@ -195,7 +202,13 @@ export class PostgresPersistenceAdapter extends PersistenceAdapter<PoolClient> {
   protected async markAllInstancesDying(
     connection: Pool | PoolClient = this.pool,
   ): Promise<void> {
-    await connection.query('UPDATE "instances" SET "dying"=TRUE');
+    // Only flip rows that are currently alive, stamping when they became
+    // dying. Rows already dying keep their original timestamp so they can age
+    // out via reapDeadInstances instead of being perpetually refreshed.
+    await connection.query(
+      'UPDATE "instances" SET "dying"=TRUE, "timestamp"=now() ' +
+        'WHERE "dying"=FALSE',
+    );
   }
 
   protected async markAllChartsPaused(

--- a/packages/core-pglite/src/PGlitePersistenceAdapter.test.ts
+++ b/packages/core-pglite/src/PGlitePersistenceAdapter.test.ts
@@ -230,4 +230,36 @@ describe('PGlitePersistenceAdapter: instance deregistration on graceful shutdown
     // Only the freshly inserted instance is alive.
     expect(await adapter.countAliveInstances()).toBe(1);
   });
+
+  it('does not reap a just-overthrown long-lived instance before it sees its death note', async () => {
+    const adapter = await PGlitePersistenceAdapter.connect();
+
+    await adapter.withTransaction(async (client) => {
+      await client.exec('DELETE FROM "instances"');
+      // A live instance that has been running far longer than the retention
+      // window, so its insert timestamp is older than the reap threshold.
+      await client.exec(
+        `INSERT INTO "instances" ("instanceId", "dying", "timestamp")
+         VALUES ('long-lived', FALSE, now() - interval '2 hours')`,
+      );
+    });
+
+    // A successor boots and overthrows. overthrowOtherInstances marks the old
+    // instance dying and then reaps. Regression: marking dying must refresh the
+    // timestamp, otherwise the old (2h) row is reaped in the same transaction —
+    // and since onDeathNote treats a missing row as "not dying", the overthrown
+    // instance would never trigger its own shutdown.
+    await adapter.overthrowOtherInstances('successor', 'cid');
+
+    const rows = await adapter.withTransaction(async (client) => {
+      return client.query<{ instanceId: string; dying: boolean }>(
+        'SELECT "instanceId", "dying" FROM "instances"',
+      );
+    });
+    const longLived = rows.rows.find((r) => r.instanceId === 'long-lived');
+
+    // Its row must survive (so its death-note poll can fire) and be marked dying.
+    expect(longLived).toBeDefined();
+    expect(longLived?.dying).toBe(true);
+  });
 });

--- a/packages/core-pglite/src/PGlitePersistenceAdapter.test.ts
+++ b/packages/core-pglite/src/PGlitePersistenceAdapter.test.ts
@@ -179,3 +179,55 @@ describe('PGlitePersistenceAdapter: orphan-locked deferred events released on st
     expect(after.rows[0].lock).toBeNull();
   });
 });
+
+describe('PGlitePersistenceAdapter: instance deregistration on graceful shutdown', () => {
+  it('removeInstance excludes the instance from countAliveInstances', async () => {
+    const adapter = await PGlitePersistenceAdapter.connect();
+
+    // overthrowOtherInstances marks all existing rows dying and inserts self
+    // as the sole alive (dying=FALSE) instance — the clean-startup state.
+    await adapter.overthrowOtherInstances('lone-instance', 'cid');
+    expect(await adapter.countAliveInstances()).toBe(1);
+
+    // Graceful shutdown calls removeInstance. Regression: this used to be a
+    // no-op, so the departing instance still counted itself as alive
+    // (countAliveInstances stayed 1), driving XJog.shutdown()'s adoption wait
+    // into an infinite loop with no successor to adopt its charts.
+    await adapter.removeInstance('lone-instance', 'cid');
+    expect(await adapter.countAliveInstances()).toBe(0);
+  });
+
+  it('reaps long-dead instance rows on startup but keeps recent ones', async () => {
+    const adapter = await PGlitePersistenceAdapter.connect();
+
+    await adapter.withTransaction(async (client) => {
+      await client.exec('DELETE FROM "instances"');
+      // Dying for longer than the retention window — should be reaped.
+      await client.exec(
+        `INSERT INTO "instances" ("instanceId", "dying", "timestamp")
+         VALUES ('stale-dead', TRUE, now() - interval '2 hours')`,
+      );
+      // Recently marked dying — within retention, must be kept.
+      await client.exec(
+        `INSERT INTO "instances" ("instanceId", "dying", "timestamp")
+         VALUES ('recent-dead', TRUE, now())`,
+      );
+    });
+
+    // overthrowOtherInstances inserts the new instance and reaps stale rows.
+    await adapter.overthrowOtherInstances('newbie', 'cid');
+
+    const rows = await adapter.withTransaction(async (client) => {
+      return client.query<{ instanceId: string }>(
+        'SELECT "instanceId" FROM "instances" ORDER BY "instanceId"',
+      );
+    });
+    const ids = rows.rows.map((r) => r.instanceId);
+
+    expect(ids).toContain('newbie');
+    expect(ids).toContain('recent-dead');
+    expect(ids).not.toContain('stale-dead');
+    // Only the freshly inserted instance is alive.
+    expect(await adapter.countAliveInstances()).toBe(1);
+  });
+});

--- a/packages/core-pglite/src/PGlitePersistenceAdapter.ts
+++ b/packages/core-pglite/src/PGlitePersistenceAdapter.ts
@@ -165,12 +165,26 @@ export class PGlitePersistenceAdapter extends PersistenceAdapter<PGlite> {
     );
   }
 
-  protected async deleteInstance(
+  protected async markInstanceDying(
     id: string,
     connection: PGlite = this.pool,
   ): Promise<void> {
-    // TODO re-enable or make a cleanup with some lookbehind period
-    // await connection.query('DELETE FROM instances WHERE "instanceId"=$1', [id]);
+    await connection.query(
+      'UPDATE "instances" SET "dying"=TRUE WHERE "instanceId"=$1',
+      [id],
+    );
+  }
+
+  protected async reapDeadInstances(
+    retentionMs: number,
+    connection: PGlite = this.pool,
+  ): Promise<void> {
+    await connection.query(
+      'DELETE FROM "instances" ' +
+        'WHERE "dying"=TRUE ' +
+        'AND "timestamp" < now() - make_interval(secs => $1)',
+      [retentionMs / 1000],
+    );
   }
 
   protected async markAllInstancesDying(

--- a/packages/core-pglite/src/PGlitePersistenceAdapter.ts
+++ b/packages/core-pglite/src/PGlitePersistenceAdapter.ts
@@ -169,8 +169,12 @@ export class PGlitePersistenceAdapter extends PersistenceAdapter<PGlite> {
     id: string,
     connection: PGlite = this.pool,
   ): Promise<void> {
+    // Refresh "timestamp" so it marks when the row entered the dying state.
+    // reapDeadInstances ages rows out relative to this, so a long-lived
+    // instance is not reaped immediately after a graceful shutdown.
     await connection.query(
-      'UPDATE "instances" SET "dying"=TRUE WHERE "instanceId"=$1',
+      'UPDATE "instances" SET "dying"=TRUE, "timestamp"=now() ' +
+        'WHERE "instanceId"=$1',
       [id],
     );
   }
@@ -190,7 +194,13 @@ export class PGlitePersistenceAdapter extends PersistenceAdapter<PGlite> {
   protected async markAllInstancesDying(
     connection: PGlite = this.pool,
   ): Promise<void> {
-    await connection.query('UPDATE "instances" SET "dying"=TRUE');
+    // Only flip rows that are currently alive, stamping when they became
+    // dying. Rows already dying keep their original timestamp so they can age
+    // out via reapDeadInstances instead of being perpetually refreshed.
+    await connection.query(
+      'UPDATE "instances" SET "dying"=TRUE, "timestamp"=now() ' +
+        'WHERE "dying"=FALSE',
+    );
   }
 
   protected async markAllChartsPaused(

--- a/packages/core/src/XJog.ts
+++ b/packages/core/src/XJog.ts
@@ -295,15 +295,25 @@ export class XJog extends XJogLogEmitter {
     // Before shutting down we must wait until all charts have been adopted.
     // This way the incoming events get handled – deferred though instead
     // of being sent to the corresponding activities.
-    if (instanceCount > 0) {
+    const { ownChartPollingFrequency, adoptionTimeout } = this.options.shutdown;
+
+    if (instanceCount > 0 && adoptionTimeout > 0) {
       trace('Waiting for charts to be adopted by others');
+      // Bound the wait: if no successor adopts the charts (e.g. the adopting
+      // instance dies mid-handoff), proceed to halt instead of blocking forever.
+      // Unadopted charts are re-adopted by the next instance on its startup.
+      const deadline = Date.now() + adoptionTimeout;
       let ownCharts = await this.persistence.countOwnCharts(this.id);
-      while (ownCharts > 0) {
-        await waitFor(this.options.shutdown.ownChartPollingFrequency);
+      while (ownCharts > 0 && Date.now() < deadline) {
+        await waitFor(ownChartPollingFrequency);
         trace('Still waiting...', { ownCharts });
         ownCharts = await this.persistence.countOwnCharts(this.id);
       }
-      trace('No more own charts left');
+      if (ownCharts > 0) {
+        trace('Adoption timed out; proceeding to halt', { ownCharts });
+      } else {
+        trace('No more own charts left');
+      }
     }
 
     trace('Emitting halt event');

--- a/packages/core/src/XJogOptions.ts
+++ b/packages/core/src/XJogOptions.ts
@@ -35,6 +35,13 @@ export type XJogOptions = {
   shutdown?: {
     /** How often to poll for own charts during the shutdown */
     ownChartPollingFrequency?: number;
+    /**
+     * Maximum time to wait for other instances to adopt this instance's charts
+     * during shutdown before proceeding to halt. Defaults to 30000 ms. Set to
+     * 0 to skip waiting entirely. Charts left unadopted on timeout are re-adopted
+     * by the next instance on its startup, so none are lost.
+     */
+    adoptionTimeout?: number;
   };
 };
 
@@ -57,6 +64,7 @@ export type ResolvedXJogOptions = {
   };
   shutdown: {
     ownChartPollingFrequency: number;
+    adoptionTimeout: number;
   };
 };
 
@@ -158,7 +166,16 @@ export function resolveShutdownOptions(
     trace,
   );
 
+  // Minimum 0 so callers can disable the adoption wait entirely.
+  const adoptionTimeout = pickIntegerOption(
+    options?.adoptionTimeout,
+    30000,
+    0,
+    trace,
+  );
+
   return {
     ownChartPollingFrequency,
+    adoptionTimeout,
   };
 }

--- a/packages/core/src/XJogShutdown.test.ts
+++ b/packages/core/src/XJogShutdown.test.ts
@@ -9,16 +9,16 @@ import { XJog } from './XJog';
  * failure instead of hanging the whole runner until the jest timeout.
  */
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string) {
-  let timer: ReturnType<typeof setTimeout>;
-  return Promise.race([
-    promise.finally(() => clearTimeout(timer)),
-    new Promise<never>((_, reject) => {
-      timer = setTimeout(
-        () => reject(new Error(`Timed out waiting for: ${label}`)),
-        ms,
-      );
-    }),
-  ]);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`Timed out waiting for: ${label}`)),
+      ms,
+    );
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
 }
 
 const machine = createMachine({

--- a/packages/core/src/XJogShutdown.test.ts
+++ b/packages/core/src/XJogShutdown.test.ts
@@ -1,0 +1,96 @@
+import { PGlitePersistenceAdapter } from '@samihult/xjog-core-pglite';
+import { createMachine } from 'xstate';
+
+import { XJog } from './XJog';
+
+/**
+ * Reject if the promise does not settle within `ms`. Used so that a regression
+ * (an infinite adoption wait in shutdown) surfaces as a fast, clear test
+ * failure instead of hanging the whole runner until the jest timeout.
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string) {
+  let timer: ReturnType<typeof setTimeout>;
+  return Promise.race([
+    promise.finally(() => clearTimeout(timer)),
+    new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error(`Timed out waiting for: ${label}`)),
+        ms,
+      );
+    }),
+  ]);
+}
+
+const machine = createMachine({
+  id: 'shutdown-machine',
+  initial: 'idle',
+  states: {
+    idle: {},
+    done: { type: 'final' },
+  },
+});
+
+describe('XJog.shutdown: lone instance must not hang', () => {
+  it('resolves and emits halt even while owning charts with no successor', async () => {
+    const persistence = await PGlitePersistenceAdapter.connect();
+    const xJog = new XJog({ persistence });
+
+    const xJogMachine = await xJog.registerMachine(machine);
+    await xJog.start();
+
+    // Own a chart so the adoption wait loop is genuinely entered. Without an
+    // owned chart the loop body never runs and the hang would not reproduce.
+    await xJogMachine.createChart();
+    expect(await persistence.countOwnCharts(xJog.id)).toBeGreaterThan(0);
+
+    const halted = xJog.waitUntilHalted();
+
+    // Regression: removeInstance used to be a no-op, so the departing instance
+    // still counted itself alive (instanceCount > 0) and waited forever for a
+    // successor that never comes. With the fix it deregisters itself,
+    // countAliveInstances drops to 0 and the wait is skipped entirely.
+    await withTimeout(xJog.shutdown(), 5000, 'lone shutdown to resolve');
+    await withTimeout(halted, 1000, 'halt event');
+
+    // The chart is left persisted for the next instance to adopt on boot.
+    expect(await persistence.countOwnCharts(xJog.id)).toBeGreaterThan(0);
+  }, 10000);
+});
+
+describe('XJog.shutdown: bounded adoption wait (adoptionTimeout)', () => {
+  it('proceeds to halt after adoptionTimeout when no one adopts the charts', async () => {
+    const persistence = await PGlitePersistenceAdapter.connect();
+    const xJog = new XJog({
+      persistence,
+      shutdown: { adoptionTimeout: 300, ownChartPollingFrequency: 50 },
+    });
+
+    const xJogMachine = await xJog.registerMachine(machine);
+    await xJog.start();
+    await xJogMachine.createChart();
+
+    // Simulate another live instance so instanceCount > 0 and the wait runs,
+    // but nobody actually adopts this instance's charts — exercising the
+    // timeout path rather than the lone-instance fast path.
+    await persistence.withTransaction(async (client) => {
+      await client.query(
+        'INSERT INTO "instances" ("instanceId", "dying") VALUES ($1, FALSE)',
+        ['phantom-successor'],
+      );
+    });
+    expect(await persistence.countAliveInstances()).toBeGreaterThan(1);
+
+    const halted = xJog.waitUntilHalted();
+
+    const before = Date.now();
+    await withTimeout(xJog.shutdown(), 5000, 'bounded shutdown to resolve');
+    await withTimeout(halted, 1000, 'halt event');
+    const elapsed = Date.now() - before;
+
+    // It waited (did not exit immediately) but did not hang past the timeout.
+    expect(elapsed).toBeGreaterThanOrEqual(250);
+    expect(elapsed).toBeLessThan(4000);
+    // Charts remain owned by this instance — handoff was skipped, not lost.
+    expect(await persistence.countOwnCharts(xJog.id)).toBeGreaterThan(0);
+  }, 10000);
+});


### PR DESCRIPTION
## Summary

`XJog.shutdown()` could block forever. A lone instance receiving SIGTERM waits for a sibling to adopt its charts, but the departing instance was **still counted as alive** because `removeInstance()` was a no-op (`deleteInstance` was commented out). So `countAliveInstances()` stayed `> 0`, the adoption loop ran with no successor, and `countOwnCharts(self)` never reached `0` — an infinite wait.

Dominant case: single-replica deploy, scale-to-zero, or the last pod of a rolling update.

## Changes

**P0 — deregister the departing instance**
- Replace the no-op `deleteInstance` with `markInstanceDying(id)` (`UPDATE "instances" SET "dying"=TRUE WHERE "instanceId"=…`) in `core-pg` and `core-pglite`.
- `removeInstance` now calls it. The departing instance is marked dying, so `countAliveInstances` (`WHERE "dying"=FALSE`) excludes it and the lone-shutdown case skips the adoption wait entirely. Consistent with the existing death-note model — no row-removal races with `onDeathNote`.

**P1 — bound the adoption wait**
- New `XJogOptions.shutdown.adoptionTimeout` (default `30000` ms; `0` disables). If a successor dies mid-handoff the loop now exits at the deadline, logs `Adoption timed out; proceeding to halt`, and proceeds. Unadopted charts are re-adopted by the next instance on startup, so none are lost.

**P2 — reap leaked instance rows (the existing TODO)**
- `reapDeadInstances(retentionMs)` deletes `dying=TRUE` rows older than a retention window (1h) during `overthrowOtherInstances`. Bounds `instances`-table growth and lets rows left behind by SIGKILL/OOM age out. No schema change.

## Behaviour matrix

| Scenario | Before | After |
|---|---|---|
| Lone instance, SIGTERM, owns charts | hangs forever | resolves immediately, emits `halt` |
| Overthrow (successor adopts) | works | unchanged — waits until adopted |
| Successor dies mid-adoption | unbounded wait | halts after `adoptionTimeout` |
| `instances` table growth | unbounded | reaped on startup past retention |

## Backward compatibility

- P0 turns a no-op into a state write; the only observable difference is that a departing instance is correctly excluded from `countAliveInstances`. The overthrow/adoption path is unchanged.
- P1 default preserves current behaviour except that an otherwise-infinite wait now terminates.
- `adoptionTimeout` is optional and resolved with a default — omitting it keeps prior behaviour (bar the hang).

## Tests

Regression tests fail before the fix, pass after (verified):

- `core-pglite`: `removeInstance` drops `countAliveInstances` to `0`; reaping deletes stale dying rows but keeps recent/alive ones.
- `core` integration (`XJogShutdown.test.ts`): lone instance owning a chart resolves and emits `halt` (times out when the fix is reverted); `adoptionTimeout` path halts after the timeout with charts still owned.

`pnpm lerna run build` / `lint` clean; core + pglite suites pass.

> Note: the `core-pg` `markInstanceDying` / `reapDeadInstances` paths compile and mirror the `core-pglite` logic but are not runtime-tested here (no Postgres in CI for this package); the equivalent behaviour is covered against PGlite.
