### PR TITLE
chore: bump pnpm to 10.34.1 (latest 10.x)

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   NODE_VERSION: 24
-  PNPM_VERSION: 10.33.0
+  PNPM_VERSION: 10.34.1
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 concurrency:

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "@xjog/packages",
   "private": true,
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@10.34.1",
   "engines": {
     "node": ">=24.x",
-    "pnpm": ">=10.33.0"
+    "pnpm": ">=10.34.1"
   },
   "scripts": {
     "watch-all": "lerna run build && lerna watch -- lerna run build --since"

--- a/packages/core-persistence/package.json
+++ b/packages/core-persistence/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "npm": ">=8.19.4",
     "node": ">=24.x",
-    "pnpm": ">=10.33.0"
+    "pnpm": ">=10.34.1"
   },
   "keywords": [
     "statechart",

--- a/packages/core-pg/package.json
+++ b/packages/core-pg/package.json
@@ -5,7 +5,7 @@
 	"engines": {
 		"npm": ">=8.19.4",
 		"node": ">=24.x",
-		"pnpm": ">=10.33.0"
+		"pnpm": ">=10.34.1"
 	},
 	"keywords": [
 		"statechart",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,7 +5,7 @@
 	"engines": {
 		"npm": ">=8.19.4",
 		"node": ">=24.x",
-		"pnpm": ">=10.33.0"
+		"pnpm": ">=10.34.1"
 	},
 	"keywords": [
 		"statechart",

--- a/packages/digest-persistence/package.json
+++ b/packages/digest-persistence/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "npm": ">=8.19.4",
     "node": ">=24.x",
-    "pnpm": ">=10.33.0"
+    "pnpm": ">=10.34.1"
   },
   "keywords": [
     "statechart",

--- a/packages/digest-pg/package.json
+++ b/packages/digest-pg/package.json
@@ -5,7 +5,7 @@
 	"engines": {
 		"npm": ">=8.19.4",
 		"node": ">=24.x",
-		"pnpm": ">=10.33.0"
+		"pnpm": ">=10.34.1"
 	},
 	"keywords": [
 		"statechart",

--- a/packages/digest-reader/package.json
+++ b/packages/digest-reader/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "npm": ">=8.19.4",
     "node": ">=24.x",
-    "pnpm": ">=10.33.0"
+    "pnpm": ">=10.34.1"
   },
   "keywords": [
     "statechart",

--- a/packages/digest-writer/package.json
+++ b/packages/digest-writer/package.json
@@ -5,7 +5,7 @@
 	"engines": {
 		"npm": ">=8.19.4",
 		"node": ">=24.x",
-		"pnpm": ">=10.33.0"
+		"pnpm": ">=10.34.1"
 	},
 	"keywords": [
 		"statechart",

--- a/packages/journal-persistence/package.json
+++ b/packages/journal-persistence/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "npm": ">=8.19.4",
     "node": ">=24.x",
-    "pnpm": ">=10.33.0"
+    "pnpm": ">=10.34.1"
   },
   "keywords": [
     "statechart",

--- a/packages/journal-pg/package.json
+++ b/packages/journal-pg/package.json
@@ -5,7 +5,7 @@
 	"engines": {
 		"npm": ">=8.19.4",
 		"node": ">=24.x",
-		"pnpm": ">=10.33.0"
+		"pnpm": ">=10.34.1"
 	},
 	"keywords": [
 		"statechart",

--- a/packages/journal-reader/package.json
+++ b/packages/journal-reader/package.json
@@ -5,7 +5,7 @@
 	"engines": {
 		"npm": ">=8.19.4",
 		"node": ">=24.x",
-		"pnpm": ">=10.33.0"
+		"pnpm": ">=10.34.1"
 	},
 	"keywords": [
 		"statechart",

--- a/packages/journal-writer/package.json
+++ b/packages/journal-writer/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "npm": ">=8.19.4",
     "node": ">=24.x",
-    "pnpm": ">=10.33.0"
+    "pnpm": ">=10.34.1"
   },
   "keywords": [
     "statechart",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -5,7 +5,7 @@
   "engines": {
     "npm": ">=8.19.4",
     "node": ">=24.x",
-    "pnpm": ">=10.33.0"
+    "pnpm": ">=10.34.1"
   },
   "keywords": [
     "statechart",


### PR DESCRIPTION
## What

Bumps the pinned pnpm version from `10.33.0` to `10.34.1`, the latest release on the 10.x line.

## Where

- `package.json` — `packageManager` pin and root `engines.pnpm` floor
- `.github/workflows/check-pr.yml` — `PNPM_VERSION` env (consumed by `pnpm/action-setup@v5`)
- `engines.pnpm` floor in all 12 workspace packages

## Why

Stay current on the 10.x toolchain. The `latest` dist-tag is now on 11.x; this intentionally keeps us on 10.x.

## Notes for reviewer

- No `pnpm-lock.yaml` change — the pnpm version is not stored in the lockfile.
- `install` not run locally against the registry; no dependency resolution changed.