### PR TITLE
perf(core): reduce per-transition deep-clones (structuredClone + drop duplicate old-state clone)

### DIFF
--- a/packages/core/bench/cloneCost.bench.mjs
+++ b/packages/core/bench/cloneCost.bench.mjs
@@ -1,0 +1,52 @@
+import { performance } from 'node:perf_hooks';
+
+// Synthesize a context roughly the size of a heavy checkout chart:
+// large journal array + nested payloads in xstate context.
+function bigContext() {
+  return {
+    cart: { itemIds: Array.from({ length: 50 }, (_, i) => `item-${i}`) },
+    subscriptionCccData: {
+      variants: Array.from({ length: 200 }, (_, i) => ({
+        id: i,
+        nak: `NAK${i}`,
+        rules: { a: i, b: `${i}`, c: [i, i + 1, i + 2] },
+      })),
+    },
+    journal: Array.from({ length: 2000 }, (_, i) => ({
+      ts: i,
+      event: `EVENT_${i % 20}`,
+      payload: { k: i, v: `value-${i}`, meta: { x: i, y: `${i}` } },
+    })),
+  };
+}
+
+function timed(label, fn, iters = 200) {
+  fn(); // warm up
+  const start = performance.now();
+  for (let i = 0; i < iters; i++) fn();
+  const ms = (performance.now() - start) / iters;
+  console.log(`${label}: ${ms.toFixed(3)} ms/op`);
+  return ms;
+}
+
+const ctx = bigContext();
+console.log(`context JSON size: ${(JSON.stringify(ctx).length / 1024).toFixed(1)} KiB\n`);
+
+// OLD per-transition hot path: old state cloned twice + new cloned once
+// (≈3 full JSON round-trips of the context) + the persist stringify.
+const oldMs = timed('OLD  ~3x JSON.parse(JSON.stringify) + 1 stringify', () => {
+  JSON.parse(JSON.stringify(ctx)); // 745 snapshot (old)
+  JSON.parse(JSON.stringify(ctx)); // mapState(previousState) re-clone of old
+  JSON.parse(JSON.stringify(ctx)); // mapState(nextState) clone of new
+  JSON.stringify(ctx); // persist write (irreducible)
+});
+
+// NEW per-transition hot path: old snapshot (structuredClone) + new
+// (structuredClone), old NOT re-cloned in resolver, + the persist stringify.
+const newMs = timed('NEW  2x structuredClone + 1 stringify (persist)', () => {
+  structuredClone(ctx); // 745 snapshot (old)
+  structuredClone(ctx); // mapState(nextState) clone of new
+  JSON.stringify(ctx); // persist write (irreducible)
+});
+
+console.log(`\nspeedup: ${(oldMs / newMs).toFixed(2)}x  (old ${oldMs.toFixed(2)} ms/op -> new ${newMs.toFixed(2)} ms/op)`);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@samihult/xjog",
-	"version": "0.0.335",
+	"version": "0.0.336",
 	"description": "XState chart runner for long-running charts",
 	"engines": {
 		"npm": ">=8.19.4",

--- a/packages/core/src/XJogChart.ts
+++ b/packages/core/src/XJogChart.ts
@@ -527,7 +527,11 @@ export class XJogChart<
       const trace = (...args: Array<string | Record<string, unknown>>) =>
         this.trace({ cid, in: 'runStep' }, ...args);
 
-      const stateBeforeTransition = JSON.parse(JSON.stringify(this.state));
+      const stateBeforeTransition = {
+        value: structuredClone(this.state.value),
+        context: structuredClone(this.state.context),
+        actions: this.state.actions,
+      } as State<TContext, TEvent, TStateSchema, TTypeState>;
 
       const missingAfterActions = await XJogChart.resolveMissingAfterActions(
         this.xJogMachine,
@@ -742,7 +746,11 @@ export class XJogChart<
       );
 
       trace({ message: 'Saving the current state' });
-      const stateBeforeTransition = JSON.parse(JSON.stringify(this.state));
+      const stateBeforeTransition = {
+        value: structuredClone(this.state.value),
+        context: structuredClone(this.state.context),
+        actions: this.state.actions,
+      } as State<TContext, TEvent, TStateSchema, TTypeState>;
 
       try {
         if (context) {

--- a/packages/core/src/XJogChart.ts
+++ b/packages/core/src/XJogChart.ts
@@ -56,6 +56,7 @@ import {
   resolveXJogCreateStateChange,
   resolveXJogDeleteStateChange,
   resolveXJogUpdateStateChange,
+  XJogStateSnapshot,
 } from './resolveXJogStateChange';
 
 import type { XJog } from './XJog';
@@ -531,9 +532,11 @@ export class XJogChart<
       // allocates a new State with a new actions array, so the pre-transition
       // array is never mutated after this snapshot. mapState (the only consumer
       // of this snapshot) reads only value/context/actions.
-      const stateBeforeTransition: Pick<
-        State<TContext, TEvent, TStateSchema, TTypeState>,
-        'value' | 'context' | 'actions'
+      const stateBeforeTransition: XJogStateSnapshot<
+        TContext,
+        TStateSchema,
+        TEvent,
+        TTypeState
       > = {
         value: structuredClone(this.state.value),
         context: structuredClone(this.state.context),
@@ -580,12 +583,7 @@ export class XJogChart<
       const change = resolveXJogUpdateStateChange(
         this.ref,
         this.parentRef,
-        stateBeforeTransition as State<
-          TContext,
-          TEvent,
-          TStateSchema,
-          TTypeState
-        >,
+        stateBeforeTransition,
         this.state,
       );
 
@@ -762,9 +760,11 @@ export class XJogChart<
       // allocates a new State with a new actions array, so the pre-transition
       // array is never mutated after this snapshot. mapState (the only consumer
       // of this snapshot) reads only value/context/actions.
-      const stateBeforeTransition: Pick<
-        State<TContext, TEvent, TStateSchema, TTypeState>,
-        'value' | 'context' | 'actions'
+      const stateBeforeTransition: XJogStateSnapshot<
+        TContext,
+        TStateSchema,
+        TEvent,
+        TTypeState
       > = {
         value: structuredClone(this.state.value),
         context: structuredClone(this.state.context),
@@ -796,12 +796,7 @@ export class XJogChart<
         const change = resolveXJogUpdateStateChange(
           this.ref,
           this.parentRef,
-          stateBeforeTransition as State<
-            TContext,
-            TEvent,
-            TStateSchema,
-            TTypeState
-          >,
+          stateBeforeTransition,
           this.state,
         );
 

--- a/packages/core/src/XJogChart.ts
+++ b/packages/core/src/XJogChart.ts
@@ -527,11 +527,18 @@ export class XJogChart<
       const trace = (...args: Array<string | Record<string, unknown>>) =>
         this.trace({ cid, in: 'runStep' }, ...args);
 
-      const stateBeforeTransition = {
+      // actions is safe by reference: xstate's machine.transition() always
+      // allocates a new State with a new actions array, so the pre-transition
+      // array is never mutated after this snapshot. mapState (the only consumer
+      // of this snapshot) reads only value/context/actions.
+      const stateBeforeTransition: Pick<
+        State<TContext, TEvent, TStateSchema, TTypeState>,
+        'value' | 'context' | 'actions'
+      > = {
         value: structuredClone(this.state.value),
         context: structuredClone(this.state.context),
         actions: this.state.actions,
-      } as State<TContext, TEvent, TStateSchema, TTypeState>;
+      };
 
       const missingAfterActions = await XJogChart.resolveMissingAfterActions(
         this.xJogMachine,
@@ -573,7 +580,12 @@ export class XJogChart<
       const change = resolveXJogUpdateStateChange(
         this.ref,
         this.parentRef,
-        stateBeforeTransition,
+        stateBeforeTransition as State<
+          TContext,
+          TEvent,
+          TStateSchema,
+          TTypeState
+        >,
         this.state,
       );
 
@@ -746,19 +758,24 @@ export class XJogChart<
       );
 
       trace({ message: 'Saving the current state' });
-      const stateBeforeTransition = {
+      // actions is safe by reference: xstate's machine.transition() always
+      // allocates a new State with a new actions array, so the pre-transition
+      // array is never mutated after this snapshot. mapState (the only consumer
+      // of this snapshot) reads only value/context/actions.
+      const stateBeforeTransition: Pick<
+        State<TContext, TEvent, TStateSchema, TTypeState>,
+        'value' | 'context' | 'actions'
+      > = {
         value: structuredClone(this.state.value),
         context: structuredClone(this.state.context),
         actions: this.state.actions,
-      } as State<TContext, TEvent, TStateSchema, TTypeState>;
+      };
 
       try {
         if (context) {
           if (isFunction(context)) {
             trace({ message: 'Reducing context' });
-            this.state.context = context(
-              JSON.parse(JSON.stringify(this.state.context)),
-            );
+            this.state.context = context(structuredClone(this.state.context));
           } else {
             trace({ message: 'Patching context' });
             this.state.context = Object.assign({}, this.state.context, context);
@@ -779,7 +796,12 @@ export class XJogChart<
         const change = resolveXJogUpdateStateChange(
           this.ref,
           this.parentRef,
-          stateBeforeTransition,
+          stateBeforeTransition as State<
+            TContext,
+            TEvent,
+            TStateSchema,
+            TTypeState
+          >,
           this.state,
         );
 

--- a/packages/core/src/resolveXJogStateChange.test.ts
+++ b/packages/core/src/resolveXJogStateChange.test.ts
@@ -44,6 +44,12 @@ describe('resolveXJogUpdateStateChange', () => {
     // old side is NOT re-cloned — it is the caller's snapshot, by reference.
     expect(change.old?.context).toBe(oldState.context);
     expect((change.old?.context as Ctx).count).toBe(0);
+
+    // The alias is live: since the resolver does not clone the old side,
+    // a caller-side mutation IS visible through change.old. Callers (XJogChart)
+    // therefore must pass an already-isolated snapshot.
+    oldState.context.blob.nested.push(999);
+    expect((change.old?.context as Ctx).blob.nested).toContain(999);
   });
 
   it('deep-clones via structuredClone, not a JSON round-trip', () => {

--- a/packages/core/src/resolveXJogStateChange.test.ts
+++ b/packages/core/src/resolveXJogStateChange.test.ts
@@ -1,5 +1,9 @@
 import { createMachine, State } from 'xstate';
-import { resolveXJogUpdateStateChange } from './resolveXJogStateChange';
+import {
+  resolveXJogCreateStateChange,
+  resolveXJogDeleteStateChange,
+  resolveXJogUpdateStateChange,
+} from './resolveXJogStateChange';
 
 type Ctx = { count: number; blob: { nested: number[] } };
 
@@ -21,8 +25,8 @@ describe('resolveXJogUpdateStateChange', () => {
     const oldState = stateWith({ count: 0, blob: { nested: [1, 2, 3] } });
     const newState = stateWith({ count: 1, blob: { nested: [9] } });
     const change = resolveXJogUpdateStateChange(ref, null, oldState, newState);
-    (oldState.context.blob.nested as number[]).push(999);
-    (newState.context.blob.nested as number[]).push(999);
+    oldState.context.blob.nested.push(999);
+    newState.context.blob.nested.push(999);
     expect(change.type).toBe('update');
     expect((change.old?.context as Ctx).count).toBe(0);
     expect((change.old?.context as Ctx).blob.nested).toEqual([1, 2, 3]);
@@ -30,12 +34,38 @@ describe('resolveXJogUpdateStateChange', () => {
     expect((change.new?.context as Ctx).blob.nested).toEqual([9]);
   });
 
-  it('does not round-trip context through JSON.stringify', () => {
-    const spy = jest.spyOn(JSON, 'stringify');
-    const oldState = stateWith({ count: 0, blob: { nested: [1] } });
-    const newState = stateWith({ count: 1, blob: { nested: [2] } });
-    resolveXJogUpdateStateChange(ref, null, oldState, newState);
-    expect(spy).not.toHaveBeenCalled();
-    spy.mockRestore();
+  it('deep-clones via structuredClone, not a JSON round-trip', () => {
+    const structuredCloneSpy = jest.spyOn(globalThis, 'structuredClone');
+    const jsonSpy = jest.spyOn(JSON, 'stringify');
+    try {
+      const oldState = stateWith({ count: 0, blob: { nested: [1] } });
+      const newState = stateWith({ count: 1, blob: { nested: [2] } });
+      jsonSpy.mockClear(); // ignore any JSON.stringify from State construction above
+      resolveXJogUpdateStateChange(ref, null, oldState, newState);
+      // New path used: at least the new state's value+context are structuredCloned.
+      expect(structuredCloneSpy).toHaveBeenCalled();
+      // And the resolver itself no longer round-trips through JSON.
+      expect(jsonSpy).not.toHaveBeenCalled();
+    } finally {
+      structuredCloneSpy.mockRestore();
+      jsonSpy.mockRestore();
+    }
+  });
+
+  it('resolveXJogCreateStateChange returns an independent context copy', () => {
+    const state = stateWith({ count: 5, blob: { nested: [1, 2] } });
+    const change = resolveXJogCreateStateChange(ref, null, state);
+    expect(change.type).toBe('create');
+    expect(change.new?.context).not.toBe(state.context);
+    expect((change.new?.context as Ctx).blob).not.toBe(state.context.blob);
+    expect((change.new?.context as Ctx).blob.nested).toEqual([1, 2]);
+  });
+
+  it('resolveXJogDeleteStateChange returns an independent context copy', () => {
+    const state = stateWith({ count: 7, blob: { nested: [3] } });
+    const change = resolveXJogDeleteStateChange(ref, null, state);
+    expect(change.type).toBe('delete');
+    expect(change.old?.context).not.toBe(state.context);
+    expect((change.old?.context as Ctx).blob.nested).toEqual([3]);
   });
 });

--- a/packages/core/src/resolveXJogStateChange.test.ts
+++ b/packages/core/src/resolveXJogStateChange.test.ts
@@ -21,17 +21,29 @@ function stateWith(ctx: Ctx): State<Ctx> {
 }
 
 describe('resolveXJogUpdateStateChange', () => {
-  it('emits independent deep copies of old and new context', () => {
+  it('clones the NEW state context independently', () => {
     const oldState = stateWith({ count: 0, blob: { nested: [1, 2, 3] } });
     const newState = stateWith({ count: 1, blob: { nested: [9] } });
+
     const change = resolveXJogUpdateStateChange(ref, null, oldState, newState);
-    oldState.context.blob.nested.push(999);
+
     newState.context.blob.nested.push(999);
+
     expect(change.type).toBe('update');
-    expect((change.old?.context as Ctx).count).toBe(0);
-    expect((change.old?.context as Ctx).blob.nested).toEqual([1, 2, 3]);
     expect((change.new?.context as Ctx).count).toBe(1);
     expect((change.new?.context as Ctx).blob.nested).toEqual([9]);
+    expect(change.new?.context).not.toBe(newState.context);
+  });
+
+  it('passes the OLD state through by reference (caller owns the snapshot)', () => {
+    const oldState = stateWith({ count: 0, blob: { nested: [1, 2, 3] } });
+    const newState = stateWith({ count: 1, blob: { nested: [9] } });
+
+    const change = resolveXJogUpdateStateChange(ref, null, oldState, newState);
+
+    // old side is NOT re-cloned — it is the caller's snapshot, by reference.
+    expect(change.old?.context).toBe(oldState.context);
+    expect((change.old?.context as Ctx).count).toBe(0);
   });
 
   it('deep-clones via structuredClone, not a JSON round-trip', () => {

--- a/packages/core/src/resolveXJogStateChange.test.ts
+++ b/packages/core/src/resolveXJogStateChange.test.ts
@@ -1,0 +1,41 @@
+import { createMachine, State } from 'xstate';
+import { resolveXJogUpdateStateChange } from './resolveXJogStateChange';
+
+type Ctx = { count: number; blob: { nested: number[] } };
+
+const machine = createMachine<Ctx>({
+  id: 'test',
+  initial: 'a',
+  context: { count: 0, blob: { nested: [1, 2, 3] } },
+  states: { a: { on: { GO: 'b' } }, b: {} },
+});
+
+const ref = { machineId: 'test', chartId: 'c1' };
+
+function stateWith(ctx: Ctx): State<Ctx> {
+  return machine.resolveState(State.from('a', ctx));
+}
+
+describe('resolveXJogUpdateStateChange', () => {
+  it('emits independent deep copies of old and new context', () => {
+    const oldState = stateWith({ count: 0, blob: { nested: [1, 2, 3] } });
+    const newState = stateWith({ count: 1, blob: { nested: [9] } });
+    const change = resolveXJogUpdateStateChange(ref, null, oldState, newState);
+    (oldState.context.blob.nested as number[]).push(999);
+    (newState.context.blob.nested as number[]).push(999);
+    expect(change.type).toBe('update');
+    expect((change.old?.context as Ctx).count).toBe(0);
+    expect((change.old?.context as Ctx).blob.nested).toEqual([1, 2, 3]);
+    expect((change.new?.context as Ctx).count).toBe(1);
+    expect((change.new?.context as Ctx).blob.nested).toEqual([9]);
+  });
+
+  it('does not round-trip context through JSON.stringify', () => {
+    const spy = jest.spyOn(JSON, 'stringify');
+    const oldState = stateWith({ count: 0, blob: { nested: [1] } });
+    const newState = stateWith({ count: 1, blob: { nested: [2] } });
+    resolveXJogUpdateStateChange(ref, null, oldState, newState);
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/packages/core/src/resolveXJogStateChange.ts
+++ b/packages/core/src/resolveXJogStateChange.ts
@@ -17,6 +17,24 @@ import {
   XJogStateChangeAction,
 } from '@samihult/xjog-util';
 
+/**
+ * Minimal slice of an xstate {@link State} that {@link mapState} reads. Callers
+ * that snapshot only `value`/`context`/`actions` (e.g. XJogChart's pre-transition
+ * state) can pass this instead of a full `State`, so no `as State` cast is needed.
+ */
+export type XJogStateSnapshot<
+  TContext = any,
+  TStateSchema extends StateSchema = any,
+  TEvent extends EventObject = EventObject,
+  TTypeState extends Typestate<TContext> = {
+    value: any;
+    context: TContext;
+  },
+> = Pick<
+  State<TContext, TEvent, TStateSchema, TTypeState>,
+  'value' | 'context' | 'actions'
+>;
+
 function mapState<
   TContext = any,
   TStateSchema extends StateSchema = any,
@@ -27,7 +45,7 @@ function mapState<
   },
   TEmitted = any,
 >(
-  state: State<TContext, TEvent, TStateSchema, TTypeState>,
+  state: XJogStateSnapshot<TContext, TStateSchema, TEvent, TTypeState>,
   // clone=false lets callers skip re-cloning a value they already snapshotted
   // (e.g. XJogChart's pre-transition state). Default clones for safety.
   clone = true,
@@ -75,7 +93,7 @@ export function resolveXJogUpdateStateChange<
 >(
   ref: ChartReference,
   parentRef: ChartReference | null,
-  previousState: State<TContext, TEvent, TStateSchema, TTypeState>,
+  previousState: XJogStateSnapshot<TContext, TStateSchema, TEvent, TTypeState>,
   nextState: State<TContext, TEvent, TStateSchema, TTypeState>,
 ): XJogStateChange {
   return {

--- a/packages/core/src/resolveXJogStateChange.ts
+++ b/packages/core/src/resolveXJogStateChange.ts
@@ -83,7 +83,7 @@ export function resolveXJogUpdateStateChange<
     ref,
     parentRef,
     event: toEventObject(nextState.event),
-    old: mapState(previousState),
+    old: mapState(previousState, false),
     new: mapState(nextState),
   };
 }

--- a/packages/core/src/resolveXJogStateChange.ts
+++ b/packages/core/src/resolveXJogStateChange.ts
@@ -28,10 +28,11 @@ function mapState<
   TEmitted = any,
 >(
   state: State<TContext, TEvent, TStateSchema, TTypeState>,
+  clone = true,
 ): XJogStateChangeState {
   return {
-    value: JSON.parse(JSON.stringify(state.value)),
-    context: JSON.parse(JSON.stringify(state.context)),
+    value: clone ? structuredClone(state.value) : state.value,
+    context: clone ? structuredClone(state.context) : state.context,
     actions: mapActions(state.actions),
   };
 }

--- a/packages/core/src/resolveXJogStateChange.ts
+++ b/packages/core/src/resolveXJogStateChange.ts
@@ -28,6 +28,8 @@ function mapState<
   TEmitted = any,
 >(
   state: State<TContext, TEvent, TStateSchema, TTypeState>,
+  // clone=false lets callers skip re-cloning a value they already snapshotted
+  // (e.g. XJogChart's pre-transition state). Default clones for safety.
   clone = true,
 ): XJogStateChangeState {
   return {


### PR DESCRIPTION
## Why
Datadog Continuous Profiler flagged main-event-loop blocking on `checkout-controller` (prod): a synchronous ~1.66s span with stack `@samihult/xjog → xstate` + `pg-protocol`. Root cause on the xjog side: every chart transition deep-clones the full machine `context` several times via `JSON.parse(JSON.stringify(...))`, all synchronous and O(context size).

## What
- `mapState` (resolveXJogStateChange): `JSON.parse(JSON.stringify())` → `structuredClone`, plus an opt-out `clone` flag.
- `XJogChart` (`send` + `runStep`): the pre-transition snapshot now `structuredClone`s only `value`/`context` (not the whole `State`), and is typed `Pick<State, 'value'|'context'|'actions'>` (actions by reference — safe: `machine.transition()` always allocates a fresh actions array; `mapState`/`mapActions` are read-only).
- `resolveXJogUpdateStateChange`: stops **re-cloning** the old state (`mapState(previousState, false)`) — callers already pass an isolated snapshot. This removes one full-context clone per transition (3 → 2).
- Reducer-path context clone also switched to `structuredClone`.
- Tests added/updated (new cloned, old by-reference, create/delete independent, structuredClone used). Benchmark added.

## Honest perf note
On Node 24, `structuredClone` is **perf-neutral** vs the JSON round-trip (bench: 0.97×) — it is **not** a speedup. The real win is the **count reduction (3→2 deep clones, ~25–33%)** plus the narrower snapshot payload. `structuredClone` is kept for clarity/single-call/safety. The `bench/cloneCost.bench.mjs` numbers and rationale are in-repo.

This is a modest, low-risk reduction that scales with context size (helps most on bloated charts). The dominant lever — shrinking what the app stores in context — is a separate change in the consuming app.

## Base
Targets the `upstream` branch (the 0.0.335 deployed line), not `main` (0.0.316, behind prod). Bumps `@samihult/xjog` → **0.0.336**. `xjog-core-pg` untouched.

## Verification
`pnpm --filter @samihult/xjog build && test && lint` — build clean, 42 passed / 3 skipped, lint 0 errors.