### PR TITLE
fix(core): fail the operation, not the engine, on chart mutex timeout

### DIFF
--- a/packages/core/src/XJogChart.ts
+++ b/packages/core/src/XJogChart.ts
@@ -492,29 +492,21 @@ export class XJogChart<
         trace({ message: 'Mutex released' });
       };
     } catch (error) {
-      trace({
-        message:
-          'Failed to acquire mutex lease. ' +
-          'This indicates a problem with the chart, an eternal loop for example. ' +
-          'Shutting down.',
+      // A timed-out acquire means this one chart is wedged — an eternal loop,
+      // or a stuck operation holding the lock. Fail only this operation. This
+      // used to shut down the whole engine (at trace level), which turned a
+      // per-chart problem into an instance-wide one: a dying engine defers
+      // every subsequent send and returns null while the process stays up.
+      this.error(logPayload, {
+        message: 'Failed to acquire chart mutex within timeout',
+        chartMutexTimeout: this.options.chartMutexTimeout,
+        error,
       });
 
-      try {
-        await this.xJog.shutdown(cid);
-
-        return async () => {
-          // No mutex, no release in nested calls
-        };
-      } catch (shutdownError) {
-        const { message } = shutdownError as Error;
-
-        throw new Error(
-          `Failed to shut down after mutex failure, details:\n` +
-            JSON.stringify(logPayload, null, 2) +
-            '\nError:\n' +
-            message,
-        );
-      }
+      throw new Error(
+        `Failed to acquire mutex for chart ${this.href} ` +
+          `within ${this.options.chartMutexTimeout} ms`,
+      );
     }
   }
 

--- a/packages/core/src/XJogChartMutexTimeout.test.ts
+++ b/packages/core/src/XJogChartMutexTimeout.test.ts
@@ -1,0 +1,83 @@
+import { PGlitePersistenceAdapter } from '@samihult/xjog-core-pglite';
+import { createMachine } from 'xstate';
+
+import { XJog } from './XJog';
+
+/**
+ * Reject if the promise does not settle within `ms`, so a regression surfaces
+ * as a fast, clear test failure instead of hanging the runner.
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string) {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`Timed out waiting for: ${label}`)),
+      ms,
+    );
+  });
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+const machine = createMachine({
+  id: 'mutex-timeout-machine',
+  initial: 'idle',
+  states: {
+    idle: {
+      on: { PING: 'idle' },
+    },
+  },
+});
+
+describe('XJogChart mutex acquire timeout', () => {
+  it('fails the blocked operation without shutting down the engine', async () => {
+    const persistence = await PGlitePersistenceAdapter.connect();
+    const xJog = new XJog({ persistence, chartMutexTimeout: 150 });
+
+    const xJogMachine = await xJog.registerMachine(machine);
+    await xJog.start();
+    const chart = await xJogMachine.createChart();
+
+    // Wedge the chart: update hooks run while the chart mutex is held, so a
+    // hook that never settles keeps the mutex locked for the first send.
+    let releaseHook!: () => void;
+    let hookEntered!: () => void;
+    const hookHeld = new Promise<void>((resolve) => {
+      releaseHook = resolve;
+    });
+    const hookEnteredPromise = new Promise<void>((resolve) => {
+      hookEntered = resolve;
+    });
+    const uninstallHook = xJog.installUpdateHook(() => {
+      hookEntered();
+      return hookHeld;
+    });
+
+    const blockedSend = chart.send('PING');
+    await withTimeout(hookEnteredPromise, 2000, 'first send to hold mutex');
+
+    // Regression: acquireMutex used to react to the timeout by shutting down
+    // the WHOLE engine (xJog.dying = true), after which every send on every
+    // chart was silently deferred and returned null while the process kept
+    // running. The timeout must fail only the blocked operation.
+    await expect(chart.send('PING')).rejects.toThrow(
+      /Failed to acquire mutex/,
+    );
+    expect(xJog.dying).toBe(false);
+
+    releaseHook();
+    uninstallHook();
+    await withTimeout(blockedSend, 2000, 'mutex-holding send to finish');
+
+    // The engine is still fully operational: the same chart accepts events.
+    const state = await withTimeout(
+      chart.send('PING'),
+      2000,
+      'send after mutex timeout',
+    );
+    expect(state).not.toBeNull();
+
+    await withTimeout(xJog.shutdown(), 5000, 'shutdown');
+  }, 15000);
+});

--- a/packages/core/src/XJogChartMutexTimeout.test.ts
+++ b/packages/core/src/XJogChartMutexTimeout.test.ts
@@ -61,9 +61,7 @@ describe('XJogChart mutex acquire timeout', () => {
     // the WHOLE engine (xJog.dying = true), after which every send on every
     // chart was silently deferred and returned null while the process kept
     // running. The timeout must fail only the blocked operation.
-    await expect(chart.send('PING')).rejects.toThrow(
-      /Failed to acquire mutex/,
-    );
+    await expect(chart.send('PING')).rejects.toThrow(/Failed to acquire mutex/);
     expect(xJog.dying).toBe(false);
 
     releaseHook();

--- a/packages/core/src/XJogDeferredEventManager.ts
+++ b/packages/core/src/XJogDeferredEventManager.ts
@@ -295,27 +295,36 @@ export class XJogDeferredEventManager {
     const timer = setTimeout(async () => {
       trace({ message: 'Sending deferred event after the wait time', delay });
 
-      if (persistedDeferredEvent.eventTo) {
-        await this.xJog.sendTo(
-          persistedDeferredEvent.eventTo,
-          persistedDeferredEvent.eventId,
-          persistedDeferredEvent.ref,
-          persistedDeferredEvent.event,
-          undefined,
-          cid,
-        );
-      } else {
-        const state = await this.xJog.sendEvent(
-          persistedDeferredEvent.ref,
-          persistedDeferredEvent.event,
-          undefined,
-          undefined,
-          cid,
-        );
+      try {
+        if (persistedDeferredEvent.eventTo) {
+          await this.xJog.sendTo(
+            persistedDeferredEvent.eventTo,
+            persistedDeferredEvent.eventId,
+            persistedDeferredEvent.ref,
+            persistedDeferredEvent.event,
+            undefined,
+            cid,
+          );
+        } else {
+          const state = await this.xJog.sendEvent(
+            persistedDeferredEvent.ref,
+            persistedDeferredEvent.event,
+            undefined,
+            undefined,
+            cid,
+          );
 
-        if (!state) {
-          trace({ level: 'warning', message: 'Failed to send event' });
+          if (!state) {
+            trace({ level: 'warning', message: 'Failed to send event' });
+          }
         }
+      } catch (error) {
+        // A rejected send (e.g. a chart mutex acquire timeout) must not become
+        // an unhandled rejection. Skip the cleanup: the persisted event stays
+        // in place, so the next instance retries it on boot.
+        trace({ level: 'error', message: 'Failed to send event', error });
+        this.deferredEventTimers.delete(persistedDeferredEvent.id);
+        return;
       }
 
       trace({ message: 'Cleaning up after sending' });


### PR DESCRIPTION
## Summary
- `XJogChart.acquireMutex` reacted to a chart-mutex acquire timeout (`chartMutexTimeout`, default 5 s) by calling `xJog.shutdown()`, logged only at trace level. One wedged chart (eternal loop, stuck transition holding the lock) killed the whole instance: with `dying=true`, every subsequent `send()` on every chart was silently written to `deferredEvents` and returned null, while the process stayed up and kept serving reads. The deferred backlog then re-wedged the engine shortly after each restart. This is the root cause of the checkout-controller zombie-pod outage in dev on 2026-06-12 (controller-side mitigation: telia-company/ecommerce#2151).
- `acquireMutex` now logs at **error** level and **throws**, failing only the operation that could not get the lock. `send()` and `destroy()` propagate the rejection to the caller (in checkout-controller this surfaces as DATA_LOSS with the actual reason instead of a null state and "reason unknown").
- Caller audit turned up one hazard: the deferred-event replay in `XJogDeferredEventManager.schedule` awaits `sendEvent` inside a bare `setTimeout(async ...)`, so a rejected send would have become an unhandled rejection (fatal under Node's default since v15). It now catches, logs, and leaves the persisted event in place so the next instance retries it on boot.
- Deliberately untouched: the dead `cancelled` check in `PostgresPersistenceAdapter.onDeathNote` — fixing it would newly enable DB-triggered engine shutdowns, which deserves its own decision.

## Test plan
- [x] New regression test `XJogChartMutexTimeout.test.ts` (PGlite, no external DB): wedges a chart via a blocking update hook (hooks run while the chart mutex is held), asserts the second send rejects with the mutex error, `xJog.dying` stays `false`, and the chart accepts events again after the hook releases
- [x] Verified the test fails before the fix (engine shuts down, test times out) and passes after
- [x] `pnpm lerna run build/lint/test --scope @samihult/xjog` all green (8 suites, 43 passed)