### PR TITLE
Live handoff between instances + pnpm 11

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -9,7 +9,6 @@ on:
 
 env:
   NODE_VERSION: 24
-  PNPM_VERSION: 10.34.1
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 concurrency:
@@ -33,9 +32,8 @@ jobs:
           fetch-depth: 1
 
       - name: Setup pnpm
+        # Version comes from the packageManager field in package.json.
         uses: pnpm/action-setup@v5
-        with:
-          version: ${{ env.PNPM_VERSION }}
 
       - name: Setup Node
         uses: actions/setup-node@v5

--- a/package.json
+++ b/package.json
@@ -1,32 +1,13 @@
 {
   "name": "@xjog/packages",
   "private": true,
-  "packageManager": "pnpm@10.34.1",
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "engines": {
     "node": ">=24.x",
-    "pnpm": ">=10.34.1"
+    "pnpm": ">=11.0.0"
   },
   "scripts": {
     "watch-all": "lerna run build && lerna watch -- lerna run build --since"
-  },
-  "pnpm": {
-    "overrides": {
-      "ansi-regex@>=5.0.0 <5.0.1": "5.0.1",
-      "minimist": "^1.2.6",
-      "shell-quote": "^1.7.3",
-      "tmp": ">=0.2.7",
-      "form-data": ">=4.0.6",
-      "tar": ">=7.5.16",
-      "piscina": ">=4.9.3",
-      "undici": ">=6.27.0",
-      "js-yaml": ">=4.2.0"
-    },
-    "onlyBuiltDependencies": [
-      "@parcel/watcher",
-      "@swc/core",
-      "nx",
-      "unrs-resolver"
-    ]
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/packages/core-persistence/package.json
+++ b/packages/core-persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-core-persistence",
-  "version": "0.0.58",
+  "version": "0.0.59",
   "description": "XJog chart abstract persistence",
   "engines": {
     "npm": ">=8.19.4",

--- a/packages/core-persistence/src/PersistenceAdapter.ts
+++ b/packages/core-persistence/src/PersistenceAdapter.ts
@@ -24,6 +24,25 @@ import type { PersistedChart, PersistedDeferredEvent } from './EntryTypes';
 export const DEAD_INSTANCE_RETENTION_MS = 60 * 60 * 1000;
 
 /**
+ * Thrown when a state write is fenced off because the chart is no longer
+ * owned by the writing instance — a sibling adopted it (stale-instance
+ * takeover, deploy handoff) or it was destroyed. The caller must drop its
+ * in-memory copy of the chart; the persisted state belongs to the new owner.
+ */
+export class ChartOwnershipLostError extends Error {
+  public constructor(
+    public readonly ref: ChartReference,
+    public readonly instanceId: string,
+  ) {
+    super(
+      `Chart ${ref.machineId}/${ref.chartId} is no longer owned by ` +
+        `instance ${instanceId}; refusing to overwrite its state`,
+    );
+    this.name = 'ChartOwnershipLostError';
+  }
+}
+
+/**
  * Abstract adapter class for XJog persistence.
  * @hideconstructor
  */
@@ -90,6 +109,93 @@ export abstract class PersistenceAdapter<
   ): Promise<void>;
 
   /**
+   * Refresh the instance row's `timestamp` so it counts as recently alive.
+   * Must not touch rows already marked dying.
+   *
+   * @abstract
+   */
+  protected abstract updateInstanceHeartbeat(
+    id: string,
+    connection?: ConnectionType,
+  ): Promise<void>;
+
+  /**
+   * Mark alive instances (other than the caller) whose heartbeat `timestamp`
+   * is older than `stalenessMs` as dying, stamping `timestamp` with the time
+   * of death like {@link markInstanceDying} does.
+   *
+   * @abstract
+   * @returns Number of instances marked dying
+   */
+  protected abstract markStaleInstancesAsDying(
+    id: string,
+    stalenessMs: number,
+    connection?: ConnectionType,
+  ): Promise<number>;
+
+  /**
+   * Pause every unpaused chart whose `ownerId` is not an alive instance
+   * (owner missing, reaped, or marked dying). Paused charts are up for
+   * adoption by the reconciler.
+   *
+   * @abstract
+   * @returns Number of charts paused
+   */
+  protected abstract pauseChartsWithoutLiveOwner(
+    connection?: ConnectionType,
+  ): Promise<number>;
+
+  /**
+   * Pause every unpaused chart owned by the given instance. Used on graceful
+   * shutdown to offer the instance's charts for adoption.
+   *
+   * @abstract
+   * @returns Number of charts paused
+   */
+  protected abstract pauseChartsOwnedBy(
+    id: string,
+    connection?: ConnectionType,
+  ): Promise<number>;
+
+  /**
+   * Release deferred-event locks held by instances that are not alive, so a
+   * surviving instance's deferred-event loop can pick the events up.
+   *
+   * @abstract
+   * @returns Number of locks released
+   */
+  protected abstract releaseDeferredEventsWithoutLiveOwner(
+    connection?: ConnectionType,
+  ): Promise<number>;
+
+  /**
+   * Atomically claim a paused chart for the given instance: set its owner and
+   * resume it, but only if it is still paused (and, when `requireIdle`, has
+   * no ongoing activities). Exactly one of several concurrent claimants wins.
+   *
+   * @abstract
+   * @returns True if this call claimed the chart
+   */
+  protected abstract claimPausedChart(
+    instanceId: string,
+    ref: ChartReference,
+    requireIdle: boolean,
+    connection?: ConnectionType,
+  ): Promise<boolean>;
+
+  /**
+   * Delete the ongoing-activity rows of a single chart. Used after forcibly
+   * adopting it, since the previous owner is gone and cannot stop them.
+   *
+   * @abstract
+   * @returns Number of deleted rows
+   */
+  protected abstract deleteOngoingActivitiesForChart(
+    ref: ChartReference,
+    connection?: ConnectionType,
+  ): Promise<number>;
+
+  /**
    * Function that notifies the callback when
    * this instance is marked as dying
    *
@@ -134,7 +240,11 @@ export abstract class PersistenceAdapter<
   ): Promise<PersistedChart<TContext, TEvent> | null>;
 
   /**
+   * Persist the chart's state. When `expectedOwnerId` is given, the write is
+   * fenced: it only applies while the chart is still owned by that instance.
+   *
    * @abstract
+   * @returns Number of updated rows (0 when the fence rejected the write)
    */
   protected abstract updateChartState<TContext, TEvent extends EventObject>(
     ref: ChartReference,
@@ -144,8 +254,9 @@ export abstract class PersistenceAdapter<
       StateSchema<TContext>,
       Typestate<TContext>
     >,
+    expectedOwnerId?: string | null,
     connection?: ConnectionType,
-  ): Promise<void>;
+  ): Promise<number>;
 
   /**
    * @abstract
@@ -413,6 +524,113 @@ export abstract class PersistenceAdapter<
     trace({ message: 'Done' });
   }
 
+  /**
+   * Register this instance as alive without disturbing live siblings. The
+   * non-violent counterpart of {@link overthrowOtherInstances}: no instance
+   * is marked dying and no chart is paused. Reaps long-dead rows in passing.
+   */
+  public async registerInstance(instanceId: string, cid: string): Promise<void> {
+    const trace = (args: Record<string, any>) =>
+      this.trace({ cid, in: 'registerInstance', ...args });
+
+    await this.withTransaction(async (connection) => {
+      trace({ message: 'Adding the instance to the list' });
+      await this.insertInstance(instanceId, connection);
+
+      trace({ message: 'Reaping long-dead instances' });
+      await this.reapDeadInstances(DEAD_INSTANCE_RETENTION_MS, connection);
+    });
+
+    trace({ message: 'Done' });
+  }
+
+  /**
+   * Refresh this instance's liveness heartbeat. Called periodically by the
+   * adoption reconciler; an instance whose heartbeat goes stale is eventually
+   * marked dying by a sibling via {@link markStaleInstancesDying}.
+   */
+  public async heartbeatInstance(instanceId: string): Promise<void> {
+    await this.updateInstanceHeartbeat(instanceId);
+  }
+
+  /**
+   * Mark alive siblings with a stale heartbeat as dying. Their charts become
+   * orphans and get paused by {@link pauseOrphanedCharts} on the same
+   * reconciler pass; their own death-note poll makes them shut down.
+   */
+  public async markStaleInstancesDying(
+    instanceId: string,
+    stalenessMs: number,
+    cid: string = getCorrelationIdentifier(),
+  ): Promise<number> {
+    const trace = (args: Record<string, any>) =>
+      this.trace({ cid, in: 'markStaleInstancesDying', ...args });
+
+    const markedCount = await this.markStaleInstancesAsDying(
+      instanceId,
+      stalenessMs,
+    );
+
+    if (markedCount > 0) {
+      trace({ message: 'Marked stale instances dying', markedCount });
+    }
+
+    return markedCount;
+  }
+
+  /**
+   * Pause charts whose owner is not alive so they can be adopted.
+   */
+  public async pauseOrphanedCharts(
+    cid: string = getCorrelationIdentifier(),
+  ): Promise<number> {
+    const trace = (args: Record<string, any>) =>
+      this.trace({ cid, in: 'pauseOrphanedCharts', ...args });
+
+    const pausedCount = await this.pauseChartsWithoutLiveOwner();
+
+    if (pausedCount > 0) {
+      trace({ message: 'Paused orphaned charts', pausedCount });
+    }
+
+    return pausedCount;
+  }
+
+  /**
+   * Pause this instance's own charts, offering them for adoption by a
+   * surviving sibling. Called on graceful shutdown.
+   */
+  public async pauseOwnCharts(
+    instanceId: string,
+    cid: string = getCorrelationIdentifier(),
+  ): Promise<number> {
+    const trace = (args: Record<string, any>) =>
+      this.trace({ cid, in: 'pauseOwnCharts', ...args });
+
+    const pausedCount = await this.pauseChartsOwnedBy(instanceId);
+
+    trace({ message: 'Paused own charts', pausedCount });
+    return pausedCount;
+  }
+
+  /**
+   * Release deferred-event locks held by non-alive instances.
+   */
+  public async releaseOrphanedDeferredEvents(
+    cid: string = getCorrelationIdentifier(),
+  ): Promise<number> {
+    const trace = (args: Record<string, any>) =>
+      this.trace({ cid, in: 'releaseOrphanedDeferredEvents', ...args });
+
+    const releasedCount = await this.releaseDeferredEventsWithoutLiveOwner();
+
+    if (releasedCount > 0) {
+      trace({ message: 'Released orphaned deferred events', releasedCount });
+    }
+
+    return releasedCount;
+  }
+
   public async removeInstance(instanceId: string, cid: string): Promise<void> {
     const trace = (args: Record<string, any>) =>
       this.trace({ cid, in: 'removeInstance', ...args });
@@ -451,9 +669,17 @@ export abstract class PersistenceAdapter<
 
     trace({ message: 'Gently adopt all idle charts' });
 
-    const adoptedChartIds =
+    // Claim each candidate atomically: with several live instances reconciling
+    // concurrently, exactly one claimant wins each chart.
+    const candidateChartIds =
       await this.getPausedChartWithNoOngoingActivitiesIds();
-    await this.changeOwnerAndResumeCharts(instanceId, adoptedChartIds);
+
+    const adoptedChartIds: ChartReference[] = [];
+    for (const ref of candidateChartIds) {
+      if (await this.claimPausedChart(instanceId, ref, true)) {
+        adoptedChartIds.push(ref);
+      }
+    }
 
     trace({ message: 'Done' });
     return adoptedChartIds;
@@ -472,14 +698,21 @@ export abstract class PersistenceAdapter<
 
     trace({ message: 'Forcibly adopt all foreign charts' });
 
-    return this.withTransaction(async (connection) => {
-      const adoptedChartIds = await this.getPausedChartIds(connection);
-      await this.deleteOngoingActivitiesForPausedCharts(connection);
-      await this.changeOwnerAndResumePausedCharts(instanceId, connection);
+    // Claim each paused chart atomically regardless of ongoing activities.
+    // The previous owner is gone, so its activity rows are stale — delete
+    // them per adopted chart (only for charts this instance actually won).
+    const candidateChartIds = await this.getPausedChartIds();
 
-      trace({ message: 'Done' });
-      return adoptedChartIds;
-    });
+    const adoptedChartIds: ChartReference[] = [];
+    for (const ref of candidateChartIds) {
+      if (await this.claimPausedChart(instanceId, ref, false)) {
+        await this.deleteOngoingActivitiesForChart(ref);
+        adoptedChartIds.push(ref);
+      }
+    }
+
+    trace({ message: 'Done' });
+    return adoptedChartIds;
   }
 
   /**
@@ -575,12 +808,22 @@ export abstract class PersistenceAdapter<
     state: State<TContext, TEvent, any, any>,
     cid = getCorrelationIdentifier(),
     connection?: ConnectionType,
+    expectedOwnerId?: string,
   ): Promise<void> {
     const trace = (args: Record<string, any>) =>
       this.trace({ cid, in: 'updateChart', ref, ...args });
 
     trace({ message: 'Storing the chart to the database' });
-    await this.updateChartState(ref, state, connection);
+    const updatedRowCount = await this.updateChartState(
+      ref,
+      state,
+      expectedOwnerId ?? null,
+      connection,
+    );
+
+    if (expectedOwnerId !== undefined && updatedRowCount === 0) {
+      throw new ChartOwnershipLostError(ref, expectedOwnerId);
+    }
 
     trace({ message: 'Done' });
   }

--- a/packages/core-pg/package.json
+++ b/packages/core-pg/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@samihult/xjog-core-pg",
-	"version": "0.0.82",
+	"version": "0.0.83",
 	"description": "XJog chart Postgres persistence",
 	"engines": {
 		"npm": ">=8.19.4",

--- a/packages/core-pg/src/PostgresPersistenceAdapter.ts
+++ b/packages/core-pg/src/PostgresPersistenceAdapter.ts
@@ -211,6 +211,116 @@ export class PostgresPersistenceAdapter extends PersistenceAdapter<PoolClient> {
     );
   }
 
+  protected async updateInstanceHeartbeat(
+    id: string,
+    connection: Pool | PoolClient = this.pool,
+  ): Promise<void> {
+    // For alive rows "timestamp" doubles as the liveness heartbeat; for dying
+    // rows it is the time of death and must not be refreshed.
+    await connection.query(
+      bind(
+        'UPDATE "instances" SET "timestamp"=now() ' +
+          'WHERE "instanceId"=:id AND "dying"=FALSE',
+        { id },
+      ),
+    );
+  }
+
+  protected async markStaleInstancesAsDying(
+    id: string,
+    stalenessMs: number,
+    connection: Pool | PoolClient = this.pool,
+  ): Promise<number> {
+    const result = await connection.query(
+      bind(
+        'UPDATE "instances" SET "dying"=TRUE, "timestamp"=now() ' +
+          'WHERE "dying"=FALSE AND "instanceId" <> :id ' +
+          'AND "timestamp" < now() - make_interval(secs => :seconds)',
+        { id, seconds: stalenessMs / 1000 },
+      ),
+    );
+    return result.rowCount ?? 0;
+  }
+
+  protected async pauseChartsWithoutLiveOwner(
+    connection: Pool | PoolClient = this.pool,
+  ): Promise<number> {
+    const result = await connection.query(
+      'UPDATE "charts" SET "paused"=TRUE ' +
+        'WHERE "paused"=FALSE AND ("ownerId" IS NULL OR "ownerId" NOT IN (' +
+        '  SELECT "instanceId" FROM "instances" WHERE "dying"=FALSE' +
+        '))',
+    );
+    return result.rowCount ?? 0;
+  }
+
+  protected async pauseChartsOwnedBy(
+    id: string,
+    connection: Pool | PoolClient = this.pool,
+  ): Promise<number> {
+    const result = await connection.query(
+      bind(
+        'UPDATE "charts" SET "paused"=TRUE ' +
+          'WHERE "paused"=FALSE AND "ownerId"=:id',
+        { id },
+      ),
+    );
+    return result.rowCount ?? 0;
+  }
+
+  protected async releaseDeferredEventsWithoutLiveOwner(
+    connection: Pool | PoolClient = this.pool,
+  ): Promise<number> {
+    const result = await connection.query(
+      'UPDATE "deferredEvents" SET "lock"=NULL ' +
+        'WHERE "lock" IS NOT NULL AND "lock" NOT IN (' +
+        '  SELECT "instanceId" FROM "instances" WHERE "dying"=FALSE' +
+        ')',
+    );
+    return result.rowCount ?? 0;
+  }
+
+  protected async claimPausedChart(
+    instanceId: string,
+    ref: ChartReference,
+    requireIdle: boolean,
+    connection: Pool | PoolClient = this.pool,
+  ): Promise<boolean> {
+    const result = await connection.query(
+      bind(
+        'UPDATE "charts" SET "ownerId"=:instanceId, "paused"=FALSE ' +
+          'WHERE "machineId"=:machineId AND "chartId"=:chartId ' +
+          'AND "paused"=TRUE ' +
+          (requireIdle
+            ? 'AND NOT EXISTS (' +
+              '  SELECT 1 FROM "ongoingActivities" ' +
+              '  WHERE "machineId"=:machineId AND "chartId"=:chartId' +
+              ') '
+            : ''),
+        {
+          instanceId,
+          machineId: ref.machineId,
+          chartId: ref.chartId,
+        },
+      ),
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  protected async deleteOngoingActivitiesForChart(
+    ref: ChartReference,
+    connection: Pool | PoolClient = this.pool,
+  ): Promise<number> {
+    const result = await connection.query(
+      bind(
+        'DELETE FROM "ongoingActivities" ' +
+          'WHERE "machineId"=:machineId AND "chartId"=:chartId',
+        { machineId: ref.machineId, chartId: ref.chartId },
+      ),
+    );
+    return result.rowCount ?? 0;
+  }
+
   protected async markAllChartsPaused(
     connection: Pool | PoolClient = this.pool,
   ): Promise<void> {
@@ -341,6 +451,12 @@ export class PostgresPersistenceAdapter extends PersistenceAdapter<PoolClient> {
         ),
       );
 
+      // Re-check after the await: cancel() may have run meanwhile, or a
+      // parallel in-flight poll may already have delivered the note.
+      if (cancelled) {
+        return;
+      }
+
       const dying = Number(result.rows[0].dying) > 0;
 
       if (dying) {
@@ -349,9 +465,7 @@ export class PostgresPersistenceAdapter extends PersistenceAdapter<PoolClient> {
           clearInterval(timer);
           timer = null;
         }
-        if (!cancelled) {
-          callback();
-        }
+        callback();
       }
     }, 500);
 
@@ -440,19 +554,23 @@ export class PostgresPersistenceAdapter extends PersistenceAdapter<PoolClient> {
   protected async updateChartState<TContext, TEvent extends EventObject>(
     ref: ChartReference,
     state: State<TContext, TEvent, StateSchema<TContext>, Typestate<TContext>>,
+    expectedOwnerId: string | null = null,
     connection: Pool | PoolClient = this.pool,
-  ): Promise<void> {
-    await connection.query(
+  ): Promise<number> {
+    const result = await connection.query(
       bind(
         'UPDATE "charts" SET "state" = :state ' +
-          'WHERE "machineId" = :machineId AND "chartId" = :chartId',
+          'WHERE "machineId" = :machineId AND "chartId" = :chartId' +
+          (expectedOwnerId !== null ? ' AND "ownerId" = :expectedOwnerId' : ''),
         {
           machineId: ref.machineId,
           chartId: ref.chartId,
           state: Buffer.from(JSON.stringify(state)),
+          ...(expectedOwnerId !== null ? { expectedOwnerId } : {}),
         },
       ),
     );
+    return result.rowCount ?? 0;
   }
 
   public async destroyChart(

--- a/packages/core-pglite/package.json
+++ b/packages/core-pglite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-core-pglite",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "Lightweight PG adapter",
   "keywords": [
     "pg"

--- a/packages/core-pglite/src/PGlitePersistenceAdapter.test.ts
+++ b/packages/core-pglite/src/PGlitePersistenceAdapter.test.ts
@@ -263,3 +263,360 @@ describe('PGlitePersistenceAdapter: instance deregistration on graceful shutdown
     expect(longLived?.dying).toBe(true);
   });
 });
+
+describe('PGlitePersistenceAdapter: live handoff primitives', () => {
+  async function seed(
+    adapter: PGlitePersistenceAdapter,
+    args: {
+      instances?: Array<{ id: string; dying?: boolean; ageSeconds?: number }>;
+      charts?: Array<{
+        machineId?: string;
+        chartId: string;
+        ownerId: string | null;
+        paused?: boolean;
+      }>;
+      activities?: Array<{ machineId?: string; chartId: string; activityId: string }>;
+      deferredLocks?: Array<{ chartId: string; lock: string | null }>;
+    },
+  ): Promise<void> {
+    await adapter.withTransaction(async (client) => {
+      await client.exec('DELETE FROM "deferredEvents"');
+      await client.exec('DELETE FROM "ongoingActivities"');
+      await client.exec('DELETE FROM "charts"');
+      await client.exec('DELETE FROM "instances"');
+
+      for (const instance of args.instances ?? []) {
+        await client.query(
+          `INSERT INTO "instances" ("instanceId", "dying", "timestamp")
+           VALUES ($1, $2, now() - make_interval(secs => $3))`,
+          [instance.id, instance.dying ?? false, instance.ageSeconds ?? 0],
+        );
+      }
+
+      for (const chart of args.charts ?? []) {
+        await client.query(
+          `INSERT INTO "charts"
+             ("machineId", "chartId", "ownerId", "paused", "state")
+           VALUES ($1, $2, $3, $4, decode('7b7d', 'hex'))`,
+          [
+            chart.machineId ?? 'machine',
+            chart.chartId,
+            chart.ownerId,
+            chart.paused ?? false,
+          ],
+        );
+      }
+
+      for (const activity of args.activities ?? []) {
+        await client.query(
+          `INSERT INTO "ongoingActivities" ("machineId", "chartId", "activityId")
+           VALUES ($1, $2, $3)`,
+          [activity.machineId ?? 'machine', activity.chartId, activity.activityId],
+        );
+      }
+
+      for (const deferred of args.deferredLocks ?? []) {
+        await client.query(
+          `INSERT INTO "deferredEvents"
+             ("machineId", "chartId", "eventId", "event", "delay", "due", "lock")
+           VALUES ('machine', $1, '"1"', '{}', 1000, now() + interval '1 hour', $2)`,
+          [deferred.chartId, deferred.lock],
+        );
+      }
+    });
+  }
+
+  async function chartRows(
+    adapter: PGlitePersistenceAdapter,
+  ): Promise<Array<{ chartId: string; ownerId: string | null; paused: boolean }>> {
+    const result = await adapter.withTransaction(async (client) =>
+      client.query<{ chartId: string; ownerId: string | null; paused: boolean }>(
+        'SELECT "chartId", "ownerId", "paused" FROM "charts" ORDER BY "chartId"',
+      ),
+    );
+    return result.rows;
+  }
+
+  it('registerInstance adds an alive row without disturbing live siblings', async () => {
+    const adapter = await PGlitePersistenceAdapter.connect();
+    await seed(adapter, {
+      instances: [
+        { id: 'sibling', ageSeconds: 10 },
+        { id: 'long-dead', dying: true, ageSeconds: 2 * 60 * 60 },
+      ],
+      charts: [{ chartId: 'c1', ownerId: 'sibling' }],
+    });
+
+    await adapter.registerInstance('newbie', 'cid');
+
+    const instances = await adapter.withTransaction(async (client) =>
+      client.query<{ instanceId: string; dying: boolean }>(
+        'SELECT "instanceId", "dying" FROM "instances" ORDER BY "instanceId"',
+      ),
+    );
+
+    // Sibling untouched, self registered alive, long-dead row reaped.
+    expect(instances.rows).toEqual([
+      { instanceId: 'newbie', dying: false },
+      { instanceId: 'sibling', dying: false },
+    ]);
+
+    // Sibling's chart neither paused nor stolen.
+    expect(await chartRows(adapter)).toEqual([
+      { chartId: 'c1', ownerId: 'sibling', paused: false },
+    ]);
+  });
+
+  it('heartbeatInstance refreshes only the own, alive row', async () => {
+    const adapter = await PGlitePersistenceAdapter.connect();
+    await seed(adapter, {
+      instances: [
+        { id: 'me', ageSeconds: 120 },
+        { id: 'other', ageSeconds: 120 },
+      ],
+    });
+
+    await adapter.heartbeatInstance('me');
+
+    const rows = await adapter.withTransaction(async (client) =>
+      client.query<{ instanceId: string; ageSeconds: number }>(
+        `SELECT "instanceId",
+                extract(epoch from now() - "timestamp") AS "ageSeconds"
+         FROM "instances" ORDER BY "instanceId"`,
+      ),
+    );
+
+    const me = rows.rows.find((row) => row.instanceId === 'me');
+    const other = rows.rows.find((row) => row.instanceId === 'other');
+    expect(Number(me?.ageSeconds)).toBeLessThan(5);
+    expect(Number(other?.ageSeconds)).toBeGreaterThan(100);
+  });
+
+  it('markStaleInstancesDying marks stale siblings but spares self, fresh and dying rows', async () => {
+    const adapter = await PGlitePersistenceAdapter.connect();
+    await seed(adapter, {
+      instances: [
+        { id: 'me', ageSeconds: 120 },
+        { id: 'stale-sibling', ageSeconds: 120 },
+        { id: 'fresh-sibling', ageSeconds: 1 },
+        { id: 'already-dying', dying: true, ageSeconds: 120 },
+      ],
+    });
+
+    await adapter.markStaleInstancesDying('me', 60_000);
+
+    const rows = await adapter.withTransaction(async (client) =>
+      client.query<{ instanceId: string; dying: boolean }>(
+        'SELECT "instanceId", "dying" FROM "instances" ORDER BY "instanceId"',
+      ),
+    );
+
+    expect(rows.rows).toEqual([
+      { instanceId: 'already-dying', dying: true },
+      { instanceId: 'fresh-sibling', dying: false },
+      { instanceId: 'me', dying: false },
+      { instanceId: 'stale-sibling', dying: true },
+    ]);
+  });
+
+  it('pauseOrphanedCharts pauses charts not owned by a live instance', async () => {
+    const adapter = await PGlitePersistenceAdapter.connect();
+    await seed(adapter, {
+      instances: [
+        { id: 'live' },
+        { id: 'dying', dying: true },
+      ],
+      charts: [
+        { chartId: 'live-owned', ownerId: 'live' },
+        { chartId: 'dying-owned', ownerId: 'dying' },
+        { chartId: 'reaped-owned', ownerId: 'gone' },
+        { chartId: 'unowned', ownerId: null },
+        { chartId: 'already-paused', ownerId: 'gone', paused: true },
+      ],
+    });
+
+    const pausedCount = await adapter.pauseOrphanedCharts('cid');
+
+    expect(pausedCount).toBe(3);
+    expect(await chartRows(adapter)).toEqual([
+      { chartId: 'already-paused', ownerId: 'gone', paused: true },
+      { chartId: 'dying-owned', ownerId: 'dying', paused: true },
+      { chartId: 'live-owned', ownerId: 'live', paused: false },
+      { chartId: 'reaped-owned', ownerId: 'gone', paused: true },
+      { chartId: 'unowned', ownerId: null, paused: true },
+    ]);
+  });
+
+  it('releaseOrphanedDeferredEvents unlocks events held by non-live instances', async () => {
+    const adapter = await PGlitePersistenceAdapter.connect();
+    await seed(adapter, {
+      instances: [
+        { id: 'live' },
+        { id: 'dying', dying: true },
+      ],
+      deferredLocks: [
+        { chartId: 'a', lock: 'live' },
+        { chartId: 'b', lock: 'dying' },
+        { chartId: 'c', lock: 'gone' },
+        { chartId: 'd', lock: null },
+      ],
+    });
+
+    await adapter.releaseOrphanedDeferredEvents('cid');
+
+    const rows = await adapter.withTransaction(async (client) =>
+      client.query<{ chartId: string; lock: string | null }>(
+        'SELECT "chartId", "lock" FROM "deferredEvents" ORDER BY "chartId"',
+      ),
+    );
+
+    expect(rows.rows).toEqual([
+      { chartId: 'a', lock: 'live' },
+      { chartId: 'b', lock: null },
+      { chartId: 'c', lock: null },
+      { chartId: 'd', lock: null },
+    ]);
+  });
+
+  it('gentle adoption claims are atomic: a chart is adopted by exactly one instance', async () => {
+    const adapter = await PGlitePersistenceAdapter.connect();
+    await seed(adapter, {
+      instances: [{ id: 'a' }, { id: 'b' }],
+      charts: [
+        { chartId: 'idle-paused', ownerId: 'gone', paused: true },
+        { chartId: 'busy-paused', ownerId: 'gone', paused: true },
+        { chartId: 'running', ownerId: 'a' },
+      ],
+      activities: [{ chartId: 'busy-paused', activityId: 'act-1' }],
+    });
+
+    const adoptedByA = await adapter.gentlyAdoptCharts('a', 'cid');
+    const adoptedByB = await adapter.gentlyAdoptCharts('b', 'cid');
+
+    // Only the idle paused chart is gently adoptable, and only once.
+    expect(adoptedByA.map((ref) => ref.chartId)).toEqual(['idle-paused']);
+    expect(adoptedByB).toEqual([]);
+
+    expect(await chartRows(adapter)).toEqual([
+      { chartId: 'busy-paused', ownerId: 'gone', paused: true },
+      { chartId: 'idle-paused', ownerId: 'a', paused: false },
+      { chartId: 'running', ownerId: 'a', paused: false },
+    ]);
+  });
+
+  it('forced adoption claims paused charts and clears their ongoing activities', async () => {
+    const adapter = await PGlitePersistenceAdapter.connect();
+    await seed(adapter, {
+      instances: [{ id: 'b' }],
+      charts: [
+        { chartId: 'busy-paused', ownerId: 'gone', paused: true },
+        { chartId: 'running', ownerId: 'b' },
+      ],
+      activities: [
+        { chartId: 'busy-paused', activityId: 'act-1' },
+        { chartId: 'running', activityId: 'act-2' },
+      ],
+    });
+
+    const adopted = await adapter.forciblyAdoptCharts('b', 'cid');
+
+    expect(adopted.map((ref) => ref.chartId)).toEqual(['busy-paused']);
+    expect(await chartRows(adapter)).toEqual([
+      { chartId: 'busy-paused', ownerId: 'b', paused: false },
+      { chartId: 'running', ownerId: 'b', paused: false },
+    ]);
+
+    const activities = await adapter.withTransaction(async (client) =>
+      client.query<{ chartId: string }>(
+        'SELECT "chartId" FROM "ongoingActivities" ORDER BY "chartId"',
+      ),
+    );
+    // The adopted chart's stale activity rows are gone; the running chart's stay.
+    expect(activities.rows).toEqual([{ chartId: 'running' }]);
+  });
+
+  it('pauseOwnCharts pauses exactly the charts owned by the instance', async () => {
+    const adapter = await PGlitePersistenceAdapter.connect();
+    await seed(adapter, {
+      instances: [{ id: 'me' }, { id: 'other' }],
+      charts: [
+        { chartId: 'mine', ownerId: 'me' },
+        { chartId: 'theirs', ownerId: 'other' },
+      ],
+    });
+
+    await adapter.pauseOwnCharts('me', 'cid');
+
+    expect(await chartRows(adapter)).toEqual([
+      { chartId: 'mine', ownerId: 'me', paused: true },
+      { chartId: 'theirs', ownerId: 'other', paused: false },
+    ]);
+  });
+});
+
+describe('PGlitePersistenceAdapter: onDeathNote', () => {
+  async function waitUntil(
+    predicate: () => boolean,
+    timeoutMs: number,
+  ): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (!predicate() && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+
+  it('calls the callback when the instance is marked dying', async () => {
+    const adapter = await PGlitePersistenceAdapter.connect();
+
+    await adapter.withTransaction(async (client) => {
+      await client.exec('DELETE FROM "instances"');
+      await client.exec(
+        `INSERT INTO "instances" ("instanceId", "dying") VALUES ('doomed', FALSE)`,
+      );
+    });
+
+    const callback = jest.fn();
+    const cancel = adapter.onDeathNote('doomed', callback);
+
+    try {
+      // Not dying yet: the poller must stay quiet.
+      await new Promise((resolve) => setTimeout(resolve, 700));
+      expect(callback).not.toHaveBeenCalled();
+
+      await adapter.withTransaction(async (client) => {
+        await client.exec(
+          `UPDATE "instances" SET "dying" = TRUE WHERE "instanceId" = 'doomed'`,
+        );
+      });
+
+      await waitUntil(() => callback.mock.calls.length > 0, 3000);
+      expect(callback).toHaveBeenCalledTimes(1);
+    } finally {
+      cancel();
+    }
+  });
+
+  it('does not call the callback after cancellation', async () => {
+    const adapter = await PGlitePersistenceAdapter.connect();
+
+    await adapter.withTransaction(async (client) => {
+      await client.exec('DELETE FROM "instances"');
+      await client.exec(
+        `INSERT INTO "instances" ("instanceId", "dying") VALUES ('spared', FALSE)`,
+      );
+    });
+
+    const callback = jest.fn();
+    const cancel = adapter.onDeathNote('spared', callback);
+    cancel();
+
+    await adapter.withTransaction(async (client) => {
+      await client.exec(
+        `UPDATE "instances" SET "dying" = TRUE WHERE "instanceId" = 'spared'`,
+      );
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 1200));
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core-pglite/src/PGlitePersistenceAdapter.test.ts
+++ b/packages/core-pglite/src/PGlitePersistenceAdapter.test.ts
@@ -275,7 +275,11 @@ describe('PGlitePersistenceAdapter: live handoff primitives', () => {
         ownerId: string | null;
         paused?: boolean;
       }>;
-      activities?: Array<{ machineId?: string; chartId: string; activityId: string }>;
+      activities?: Array<{
+        machineId?: string;
+        chartId: string;
+        activityId: string;
+      }>;
       deferredLocks?: Array<{ chartId: string; lock: string | null }>;
     },
   ): Promise<void> {
@@ -311,7 +315,11 @@ describe('PGlitePersistenceAdapter: live handoff primitives', () => {
         await client.query(
           `INSERT INTO "ongoingActivities" ("machineId", "chartId", "activityId")
            VALUES ($1, $2, $3)`,
-          [activity.machineId ?? 'machine', activity.chartId, activity.activityId],
+          [
+            activity.machineId ?? 'machine',
+            activity.chartId,
+            activity.activityId,
+          ],
         );
       }
 
@@ -328,9 +336,15 @@ describe('PGlitePersistenceAdapter: live handoff primitives', () => {
 
   async function chartRows(
     adapter: PGlitePersistenceAdapter,
-  ): Promise<Array<{ chartId: string; ownerId: string | null; paused: boolean }>> {
+  ): Promise<
+    Array<{ chartId: string; ownerId: string | null; paused: boolean }>
+  > {
     const result = await adapter.withTransaction(async (client) =>
-      client.query<{ chartId: string; ownerId: string | null; paused: boolean }>(
+      client.query<{
+        chartId: string;
+        ownerId: string | null;
+        paused: boolean;
+      }>(
         'SELECT "chartId", "ownerId", "paused" FROM "charts" ORDER BY "chartId"',
       ),
     );
@@ -422,10 +436,7 @@ describe('PGlitePersistenceAdapter: live handoff primitives', () => {
   it('pauseOrphanedCharts pauses charts not owned by a live instance', async () => {
     const adapter = await PGlitePersistenceAdapter.connect();
     await seed(adapter, {
-      instances: [
-        { id: 'live' },
-        { id: 'dying', dying: true },
-      ],
+      instances: [{ id: 'live' }, { id: 'dying', dying: true }],
       charts: [
         { chartId: 'live-owned', ownerId: 'live' },
         { chartId: 'dying-owned', ownerId: 'dying' },
@@ -450,10 +461,7 @@ describe('PGlitePersistenceAdapter: live handoff primitives', () => {
   it('releaseOrphanedDeferredEvents unlocks events held by non-live instances', async () => {
     const adapter = await PGlitePersistenceAdapter.connect();
     await seed(adapter, {
-      instances: [
-        { id: 'live' },
-        { id: 'dying', dying: true },
-      ],
+      instances: [{ id: 'live' }, { id: 'dying', dying: true }],
       deferredLocks: [
         { chartId: 'a', lock: 'live' },
         { chartId: 'b', lock: 'dying' },

--- a/packages/core-pglite/src/PGlitePersistenceAdapter.ts
+++ b/packages/core-pglite/src/PGlitePersistenceAdapter.ts
@@ -203,6 +203,100 @@ export class PGlitePersistenceAdapter extends PersistenceAdapter<PGlite> {
     );
   }
 
+  protected async updateInstanceHeartbeat(
+    id: string,
+    connection: PGlite = this.pool,
+  ): Promise<void> {
+    // For alive rows "timestamp" doubles as the liveness heartbeat; for dying
+    // rows it is the time of death and must not be refreshed.
+    await connection.query(
+      'UPDATE "instances" SET "timestamp"=now() ' +
+        'WHERE "instanceId"=$1 AND "dying"=FALSE',
+      [id],
+    );
+  }
+
+  protected async markStaleInstancesAsDying(
+    id: string,
+    stalenessMs: number,
+    connection: PGlite = this.pool,
+  ): Promise<number> {
+    const result = await connection.query(
+      'UPDATE "instances" SET "dying"=TRUE, "timestamp"=now() ' +
+        'WHERE "dying"=FALSE AND "instanceId" <> $1 ' +
+        'AND "timestamp" < now() - make_interval(secs => $2)',
+      [id, stalenessMs / 1000],
+    );
+    return result.affectedRows ?? 0;
+  }
+
+  protected async pauseChartsWithoutLiveOwner(
+    connection: PGlite = this.pool,
+  ): Promise<number> {
+    const result = await connection.query(
+      'UPDATE "charts" SET "paused"=TRUE ' +
+        'WHERE "paused"=FALSE AND ("ownerId" IS NULL OR "ownerId" NOT IN (' +
+        '  SELECT "instanceId" FROM "instances" WHERE "dying"=FALSE' +
+        '))',
+    );
+    return result.affectedRows ?? 0;
+  }
+
+  protected async pauseChartsOwnedBy(
+    id: string,
+    connection: PGlite = this.pool,
+  ): Promise<number> {
+    const result = await connection.query(
+      'UPDATE "charts" SET "paused"=TRUE ' +
+        'WHERE "paused"=FALSE AND "ownerId"=$1',
+      [id],
+    );
+    return result.affectedRows ?? 0;
+  }
+
+  protected async releaseDeferredEventsWithoutLiveOwner(
+    connection: PGlite = this.pool,
+  ): Promise<number> {
+    const result = await connection.query(
+      'UPDATE "deferredEvents" SET "lock"=NULL ' +
+        'WHERE "lock" IS NOT NULL AND "lock" NOT IN (' +
+        '  SELECT "instanceId" FROM "instances" WHERE "dying"=FALSE' +
+        ')',
+    );
+    return result.affectedRows ?? 0;
+  }
+
+  protected async claimPausedChart(
+    instanceId: string,
+    ref: ChartReference,
+    requireIdle: boolean,
+    connection: PGlite = this.pool,
+  ): Promise<boolean> {
+    const result = await connection.query(
+      'UPDATE "charts" SET "ownerId"=$1, "paused"=FALSE ' +
+        'WHERE "machineId"=$2 AND "chartId"=$3 AND "paused"=TRUE ' +
+        (requireIdle
+          ? 'AND NOT EXISTS (' +
+            '  SELECT 1 FROM "ongoingActivities" ' +
+            '  WHERE "machineId"=$2 AND "chartId"=$3' +
+            ') '
+          : ''),
+      [instanceId, ref.machineId, ref.chartId],
+    );
+    return (result.affectedRows ?? 0) > 0;
+  }
+
+  protected async deleteOngoingActivitiesForChart(
+    ref: ChartReference,
+    connection: PGlite = this.pool,
+  ): Promise<number> {
+    const result = await connection.query(
+      'DELETE FROM "ongoingActivities" WHERE "machineId"=$1 AND "chartId"=$2',
+      [ref.machineId, ref.chartId],
+    );
+    return result.affectedRows ?? 0;
+  }
+
   protected async markAllChartsPaused(
     connection: PGlite = this.pool,
   ): Promise<void> {
@@ -320,6 +414,12 @@ export class PGlitePersistenceAdapter extends PersistenceAdapter<PGlite> {
         [instanceId],
       );
 
+      // Re-check after the await: cancel() may have run meanwhile, or a
+      // parallel in-flight poll may already have delivered the note.
+      if (cancelled) {
+        return;
+      }
+
       const dying = Number(result.rows[0].dying) > 0;
 
       if (dying) {
@@ -328,9 +428,7 @@ export class PGlitePersistenceAdapter extends PersistenceAdapter<PGlite> {
           clearInterval(timer);
           timer = null;
         }
-        if (!cancelled) {
-          callback();
-        }
+        callback();
       }
     }, 500);
 
@@ -408,13 +506,21 @@ export class PGlitePersistenceAdapter extends PersistenceAdapter<PGlite> {
   protected async updateChartState<TContext, TEvent extends EventObject>(
     ref: ChartReference,
     state: State<TContext, TEvent, StateSchema<TContext>, Typestate<TContext>>,
+    expectedOwnerId: string | null = null,
     connection: PGlite = this.pool,
-  ): Promise<void> {
-    await connection.query(
+  ): Promise<number> {
+    const result = await connection.query(
       'UPDATE "charts" SET "state" = $1 ' +
-        'WHERE "machineId" = $2 AND "chartId" = $3 ',
-      [Buffer.from(JSON.stringify(state)), ref.machineId, ref.chartId],
+        'WHERE "machineId" = $2 AND "chartId" = $3 ' +
+        (expectedOwnerId !== null ? 'AND "ownerId" = $4 ' : ''),
+      [
+        Buffer.from(JSON.stringify(state)),
+        ref.machineId,
+        ref.chartId,
+        ...(expectedOwnerId !== null ? [expectedOwnerId] : []),
+      ],
     );
+    return result.affectedRows ?? 0;
   }
 
   public async destroyChart(
@@ -837,7 +943,11 @@ export class PGlitePersistenceAdapter extends PersistenceAdapter<PGlite> {
           }
         : null,
 
-      state: JSON.parse(row.state.toString()) as StateConfig<TContext, TEvent>,
+      // PGlite returns bytea as Uint8Array, whose toString() yields
+      // comma-joined byte values instead of text — decode explicitly.
+      state: JSON.parse(
+        Buffer.from(row.state).toString('utf-8'),
+      ) as StateConfig<TContext, TEvent>,
 
       paused: row.paused,
     };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@samihult/xjog",
-	"version": "0.0.339",
+	"version": "0.0.340",
 	"description": "XState chart runner for long-running charts",
 	"engines": {
 		"npm": ">=8.19.4",

--- a/packages/core/src/XJog.ts
+++ b/packages/core/src/XJog.ts
@@ -275,6 +275,13 @@ export class XJog extends XJogLogEmitter {
     trace('Preparing to die');
     this.dying = true;
 
+    // Stop the adoption reconciler before deregistering: once this instance
+    // is marked dying its charts count as orphans, and a still-running
+    // reconciler would pause them and claim them right back, fighting the
+    // successor that is trying to adopt them.
+    trace('Stopping the adoption reconciler');
+    await this.startupManager.stop();
+
     trace('Removing instance from database');
     await this.persistence.removeInstance(this.id, cid);
 
@@ -283,11 +290,6 @@ export class XJog extends XJogLogEmitter {
 
     trace('Stopping all ongoing activities');
     await this.activityManager.stopAllActivities(cid);
-
-    if (!this.startupManager.ready) {
-      trace('Startup still working, stopping');
-      await this.startupManager.stop();
-    }
 
     const instanceCount = await this.persistence.countAliveInstances();
 

--- a/packages/core/src/XJogChart.test.ts
+++ b/packages/core/src/XJogChart.test.ts
@@ -465,3 +465,51 @@ describe('XJogChart: named delay on re-entry after parallel onDone', () => {
     expect(typeof secondCycleDeferCalls[0][0].delay).toBe('number');
   });
 });
+
+describe('XJogChart: ownership fencing on state writes', () => {
+  it('refuses to overwrite a chart another instance owns and evicts it from the cache', async () => {
+    const persistence = await PGlitePersistenceAdapter.connect();
+    const xJog = buildMockXJog(persistence);
+
+    const machine = createMachine({
+      id: 'fencing-machine',
+      initial: 'idle',
+      states: {
+        idle: { on: { go: 'done' } },
+        done: { type: 'final' },
+      },
+    });
+
+    const xJogMachine = new XJogMachine(xJog, machine);
+    const chart = await xJogMachine.createChart();
+
+    // A sibling instance adopts the chart behind this instance's back
+    // (stale-instance takeover while this event loop was wedged).
+    await persistence.withTransaction(async (client) => {
+      await client.query('UPDATE "charts" SET "ownerId" = $1', ['usurper']);
+    });
+
+    // The fenced write must not go through; send reports failure with null.
+    const result = await chart.send('go');
+    expect(result).toBeNull();
+
+    // The persisted state is untouched — still the owner's version.
+    const persisted = await persistence.withTransaction(async (client) =>
+      client.query<{ ownerId: string; state: Uint8Array }>(
+        'SELECT "ownerId", "state" FROM "charts"',
+      ),
+    );
+    expect(persisted.rows[0].ownerId).toBe('usurper');
+    const persistedState = JSON.parse(
+      Buffer.from(persisted.rows[0].state).toString('utf-8'),
+    );
+    expect(persistedState.value).toBe('idle');
+
+    // The stale chart object is evicted so the next getChart reloads from
+    // the database instead of serving the poisoned in-memory copy.
+    // Eviction is asynchronous (it waits for the send mutex to release).
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const reloaded = await xJogMachine.getChart(chart.id);
+    expect(reloaded).not.toBe(chart);
+  });
+});

--- a/packages/core/src/XJogChart.ts
+++ b/packages/core/src/XJogChart.ts
@@ -1,7 +1,8 @@
 import { randomUUID } from 'node:crypto';
-import type {
-  PersistedDeferredEvent,
-  PersistenceAdapter,
+import {
+  ChartOwnershipLostError,
+  type PersistedDeferredEvent,
+  type PersistenceAdapter,
 } from '@samihult/xjog-core-persistence';
 import {
   type ActivityRef,
@@ -794,7 +795,15 @@ export class XJogChart<
 
         await this.xJog.timeExecution('chart.send.update chart', async () => {
           trace({ message: 'Updating chart' });
-          await this.persistence.updateChart(this.ref, this.state, cid);
+          // Fenced write: applies only while this instance still owns the
+          // chart, so a sibling that adopted it cannot be overwritten.
+          await this.persistence.updateChart(
+            this.ref,
+            this.state,
+            cid,
+            undefined,
+            this.xJog.id,
+          );
         });
 
         for (const hook of this.xJog.updateHooks) {
@@ -823,6 +832,21 @@ export class XJogChart<
           },
         );
       } catch (err) {
+        if (err instanceof ChartOwnershipLostError) {
+          // A sibling adopted this chart (deploy handoff or stale-instance
+          // takeover). The in-memory copy is stale; evict it so the next
+          // getChart reloads the owner's state from the database. Eviction
+          // waits for this send's mutex to release, so it must not be
+          // awaited here.
+          error('Chart ownership lost, dropping the local copy', { err });
+          this.xJogMachine
+            .evictCacheEntry(this.id)
+            .catch((evictError) =>
+              error('Failed to evict chart from cache', { err: evictError }),
+            );
+          return null;
+        }
+
         error('Failed to send event, returning null', { err });
         return null;
       } finally {

--- a/packages/core/src/XJogOptions.ts
+++ b/packages/core/src/XJogOptions.ts
@@ -23,6 +23,13 @@ export type XJogOptions = {
      * Defaults to false.
      */
     skipRunningActionsOnRehydrate?: boolean;
+    /**
+     * How long a sibling instance's heartbeat may lag before the reconciler
+     * declares it dead: it is marked dying and its charts are paused and
+     * adopted. Must comfortably exceed the longest expected event-loop stall
+     * of a healthy instance. Defaults to 60000 ms.
+     */
+    instanceStaleness?: number;
   };
   deferredEvents?: {
     /** Number of deferred events to process at a time */
@@ -56,6 +63,7 @@ export type ResolvedXJogOptions = {
     adoptionFrequency: number;
     gracePeriod: number;
     skipRunningActionsOnRehydrate: boolean;
+    instanceStaleness: number;
   };
   deferredEvents: {
     batchSize: number;
@@ -120,10 +128,18 @@ export function resolveXJogStartupOptions(
   const skipRunningActionsOnRehydrate =
     options?.skipRunningActionsOnRehydrate ?? false;
 
+  const instanceStaleness = pickIntegerOption(
+    options?.instanceStaleness,
+    60 * 1000,
+    2 * adoptionFrequency,
+    trace,
+  );
+
   return {
     adoptionFrequency,
     gracePeriod,
     skipRunningActionsOnRehydrate,
+    instanceStaleness,
   };
 }
 

--- a/packages/core/src/XJogShutdown.test.ts
+++ b/packages/core/src/XJogShutdown.test.ts
@@ -57,6 +57,68 @@ describe('XJog.shutdown: lone instance must not hang', () => {
   }, 10000);
 });
 
+describe('XJog live handoff: rolling deploy between two instances', () => {
+  it('boots beside a serving sibling without disturbing it, then adopts its charts when it drains', async () => {
+    const persistence = await PGlitePersistenceAdapter.connect();
+
+    const fastReconcile = {
+      startup: { adoptionFrequency: 50, gracePeriod: 200 },
+      shutdown: { adoptionTimeout: 5000, ownChartPollingFrequency: 50 },
+    };
+
+    // Instance A: the currently serving predecessor.
+    const instanceA = new XJog({ persistence, ...fastReconcile });
+    const machineA = await instanceA.registerMachine(machine);
+    await instanceA.start();
+    await machineA.createChart();
+    expect(await persistence.countOwnCharts(instanceA.id)).toBe(1);
+
+    // Instance B: the successor boots while A is still serving.
+    const instanceB = new XJog({ persistence, ...fastReconcile });
+    await instanceB.registerMachine(machine);
+    await instanceB.start();
+
+    // Non-violent boot: A keeps its chart and stays alive through several
+    // of B's reconciler cycles.
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    expect(await persistence.countOwnCharts(instanceA.id)).toBe(1);
+    expect(await persistence.countAliveInstances()).toBe(2);
+
+    // A drains, like on SIGTERM during a deploy. The shutdown must resolve
+    // because B adopts — well before the 5s adoption timeout.
+    const before = Date.now();
+    await withTimeout(instanceA.shutdown(), 4000, 'draining shutdown');
+    const elapsed = Date.now() - before;
+
+    expect(await persistence.countOwnCharts(instanceA.id)).toBe(0);
+    expect(await persistence.countOwnCharts(instanceB.id)).toBe(1);
+    // Resolved via adoption, not via the bounded-wait timeout.
+    expect(elapsed).toBeLessThan(3000);
+
+    await instanceB.shutdown();
+  }, 15000);
+});
+
+describe('XJog.shutdown: reconciler must stop', () => {
+  it('stops the adoption reconciler so a dying instance cannot re-claim charts', async () => {
+    const persistence = await PGlitePersistenceAdapter.connect();
+    const xJog = new XJog({
+      persistence,
+      startup: { adoptionFrequency: 50, gracePeriod: 200 },
+    });
+
+    await xJog.registerMachine(machine);
+    await xJog.start();
+    await withTimeout(xJog.shutdown(), 5000, 'lone shutdown to resolve');
+
+    // A dying instance running its reconciler would pause its own (now
+    // orphaned) charts and claim them right back, fighting the successor.
+    const gentlyAdopt = jest.spyOn(persistence, 'gentlyAdoptCharts');
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    expect(gentlyAdopt).not.toHaveBeenCalled();
+  }, 10000);
+});
+
 describe('XJog.shutdown: bounded adoption wait (adoptionTimeout)', () => {
   it('proceeds to halt after adoptionTimeout when no one adopts the charts', async () => {
     const persistence = await PGlitePersistenceAdapter.connect();

--- a/packages/core/src/XJogStartupManager.test.ts
+++ b/packages/core/src/XJogStartupManager.test.ts
@@ -18,6 +18,7 @@ function mockXJogWithStartupManager(
       startup: {
         adoptionFrequency: 20,
         gracePeriod: 75,
+        instanceStaleness: 60_000,
       },
     },
   };
@@ -25,6 +26,10 @@ function mockXJogWithStartupManager(
   xJog.startupManager = new XJogStartupManager(xJog);
 
   return [xJog as unknown as XJog, xJog.startupManager];
+}
+
+async function waitFor(milliseconds: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, milliseconds));
 }
 
 describe('XJogStartupManager', () => {
@@ -44,12 +49,16 @@ describe('XJogStartupManager', () => {
 
     expect(startupManager.started).toBe(true);
     expect(startupManager.ready).toBe(true);
+
+    // The reconciler loop runs until stopped; clean it up so jest can exit.
+    await startupManager.stop();
   });
 
   it('Executes the right routines during the startup', async () => {
     const persistence = await PGlitePersistenceAdapter.connect();
     const [, startupManager] = mockXJogWithStartupManager(persistence);
 
+    jest.spyOn(persistence, 'registerInstance');
     jest.spyOn(persistence, 'overthrowOtherInstances');
     // @ts-expect-error Private access
     jest.spyOn(startupManager, 'startAdoptionGracePeriod');
@@ -58,11 +67,168 @@ describe('XJogStartupManager', () => {
 
     await startupManager.start();
 
-    expect(persistence.overthrowOtherInstances).toHaveBeenCalled();
+    // Non-violent boot: register self, never stage a coup against siblings.
+    expect(persistence.registerInstance).toHaveBeenCalled();
+    expect(persistence.overthrowOtherInstances).not.toHaveBeenCalled();
     // @ts-expect-error Private access
     expect(startupManager.startAdoptionGracePeriod).toHaveBeenCalled();
     // @ts-expect-error Private access
     expect(startupManager.adoptCharts).toHaveBeenCalled();
+
+    await startupManager.stop();
+  });
+});
+
+describe('XJogStartupManager: live handoff', () => {
+  async function seedInstance(
+    persistence: PersistenceAdapter,
+    id: string,
+    ageSeconds = 0,
+  ): Promise<void> {
+    await persistence.withTransaction(async (client: any) => {
+      await client.query(
+        `INSERT INTO "instances" ("instanceId", "dying", "timestamp")
+         VALUES ($1, FALSE, now() - make_interval(secs => $2))`,
+        [id, ageSeconds],
+      );
+    });
+  }
+
+  async function seedChart(
+    persistence: PersistenceAdapter,
+    chartId: string,
+    ownerId: string,
+    paused = false,
+  ): Promise<void> {
+    await persistence.withTransaction(async (client: any) => {
+      await client.query(
+        `INSERT INTO "charts"
+           ("machineId", "chartId", "ownerId", "paused", "state")
+         VALUES ('machine', $1, $2, $3, decode('7b7d', 'hex'))`,
+        [chartId, ownerId, paused],
+      );
+    });
+  }
+
+  async function readCharts(
+    persistence: PersistenceAdapter,
+  ): Promise<Array<{ chartId: string; ownerId: string; paused: boolean }>> {
+    const result = await persistence.withTransaction(async (client: any) =>
+      client.query(
+        'SELECT "chartId", "ownerId", "paused" FROM "charts" ORDER BY "chartId"',
+      ),
+    );
+    return (result as any).rows;
+  }
+
+  async function readInstances(
+    persistence: PersistenceAdapter,
+  ): Promise<Array<{ instanceId: string; dying: boolean }>> {
+    const result = await persistence.withTransaction(async (client: any) =>
+      client.query(
+        'SELECT "instanceId", "dying" FROM "instances" ORDER BY "instanceId"',
+      ),
+    );
+    return (result as any).rows;
+  }
+
+  it('Boot leaves a live sibling and its charts untouched', async () => {
+    const persistence = await PGlitePersistenceAdapter.connect();
+    const [, startupManager] = mockXJogWithStartupManager(persistence);
+
+    await seedInstance(persistence, 'sibling');
+    await seedChart(persistence, 'sibling-chart', 'sibling');
+
+    await startupManager.start();
+
+    expect(await readInstances(persistence)).toEqual([
+      { instanceId: 'sibling', dying: false },
+      { instanceId: 'xjog-id', dying: false },
+    ]);
+    expect(await readCharts(persistence)).toEqual([
+      { chartId: 'sibling-chart', ownerId: 'sibling', paused: false },
+    ]);
+    // Nothing to adopt, so the boot is immediately ready.
+    expect(startupManager.ready).toBe(true);
+
+    await startupManager.stop();
+  });
+
+  it('Reconciler adopts charts paused by a departing sibling after readiness', async () => {
+    const persistence = await PGlitePersistenceAdapter.connect();
+    const [xJog, startupManager] = mockXJogWithStartupManager(persistence);
+
+    const runStep = jest.fn().mockResolvedValue(undefined);
+    (xJog as any).getChart = jest.fn().mockResolvedValue({ runStep });
+
+    await startupManager.start();
+    expect(startupManager.ready).toBe(true);
+
+    // A sibling drains and pauses its chart AFTER our startup completed.
+    await seedChart(persistence, 'handed-over', 'departed-sibling', true);
+
+    await waitFor(200); // several reconciler cycles at 20ms
+
+    expect(await readCharts(persistence)).toEqual([
+      { chartId: 'handed-over', ownerId: 'xjog-id', paused: false },
+    ]);
+    expect(runStep).toHaveBeenCalled();
+
+    await startupManager.stop();
+  });
+
+  it('Reconciler marks a stale sibling dying and adopts its charts', async () => {
+    const persistence = await PGlitePersistenceAdapter.connect();
+    const [xJog, startupManager] = mockXJogWithStartupManager(persistence);
+    (xJog as any).options.startup.instanceStaleness = 50;
+
+    const runStep = jest.fn().mockResolvedValue(undefined);
+    (xJog as any).getChart = jest.fn().mockResolvedValue({ runStep });
+
+    // Crashed sibling: alive row with an ancient heartbeat, unpaused chart.
+    await seedInstance(persistence, 'crashed-sibling', 3600);
+    await seedChart(persistence, 'stranded-chart', 'crashed-sibling');
+
+    await startupManager.start();
+    await waitFor(200);
+
+    const instances = await readInstances(persistence);
+    expect(instances).toContainEqual({
+      instanceId: 'crashed-sibling',
+      dying: true,
+    });
+    expect(await readCharts(persistence)).toEqual([
+      { chartId: 'stranded-chart', ownerId: 'xjog-id', paused: false },
+    ]);
+
+    await startupManager.stop();
+  });
+
+  it('Reconciler heartbeats the own instance row', async () => {
+    const persistence = await PGlitePersistenceAdapter.connect();
+    const [, startupManager] = mockXJogWithStartupManager(persistence);
+
+    await startupManager.start();
+
+    // Age the own row artificially; the next cycles must refresh it.
+    await persistence.withTransaction(async (client: any) => {
+      await client.query(
+        `UPDATE "instances" SET "timestamp" = now() - interval '1 hour'
+         WHERE "instanceId" = 'xjog-id'`,
+      );
+    });
+
+    await waitFor(100);
+
+    const result = await persistence.withTransaction(async (client: any) =>
+      client.query(
+        `SELECT extract(epoch from now() - "timestamp") AS "ageSeconds"
+         FROM "instances" WHERE "instanceId" = 'xjog-id'`,
+      ),
+    );
+    expect(Number((result as any).rows[0].ageSeconds)).toBeLessThan(5);
+
+    await startupManager.stop();
   });
 });
 

--- a/packages/core/src/XJogStartupManager.ts
+++ b/packages/core/src/XJogStartupManager.ts
@@ -43,6 +43,8 @@ export class XJogStartupManager {
   private startupGracePeriodTimer: NodeJS.Timeout | null = null;
   /** @private Timer for adoption loop */
   private adoptionLoopTimer: NodeJS.Timeout | null = null;
+  /** @private Set by {@link #stop}; prevents an in-flight pass from rescheduling */
+  private stopping = false;
 
   public constructor(private readonly xJog: XJog) {
     this.options = xJog.options.startup;
@@ -65,8 +67,13 @@ export class XJogStartupManager {
   }
 
   /**
-   * Start charts and activities. Start adoption process of
-   * old instances' charts. Call this after registering all the machines.
+   * Start charts and activities. Start the adoption reconciler that picks up
+   * charts paused by departing siblings or stranded by crashed ones. Call
+   * this after registering all the machines.
+   *
+   * Live siblings are left alone: this instance registers itself and adopts
+   * only charts that are up for adoption, so a booting instance never
+   * disturbs one that is still serving.
    *
    * @param cid Optional correlation id for debugging purposes.
    */
@@ -74,13 +81,13 @@ export class XJogStartupManager {
     const trace = (args: Record<string, any>) =>
       this.xJog.trace({ cid, in: 'startupManager.start', ...args });
 
-    trace({ message: 'Overthrowing other instances' });
-    await this.xJog.persistence.overthrowOtherInstances(this.xJog.id, cid);
+    trace({ message: 'Registering this instance' });
+    await this.xJog.persistence.registerInstance(this.xJog.id, cid);
 
     trace({ message: 'Entering the adoption grace period' });
     this.startAdoptionGracePeriod();
 
-    trace({ message: 'Starting adoption process' });
+    trace({ message: 'Starting adoption reconciler' });
     await this.adoptCharts();
 
     trace({ message: 'Startup completed' });
@@ -91,10 +98,12 @@ export class XJogStartupManager {
     const trace = (args: Record<string, any>) =>
       this.xJog.trace({ cid, in: 'startupManager.stop', ...args });
 
+    this.stopping = true;
+
     trace({ message: 'Exiting the adoption grace period' });
     this.exitAdoptionGracePeriod();
 
-    trace({ message: 'Stopping adoption process' });
+    trace({ message: 'Stopping adoption reconciler' });
     this.stopAdoptionLoop();
 
     trace({ message: 'Signal readiness' });
@@ -109,10 +118,20 @@ export class XJogStartupManager {
   }
 
   /**
-   * Adopt charts until there are no charts left to adopt. This is the gentle
-   * option, and only paused charts that have zero activity counter will be
-   * adopted. If this fails, {@link #forciblyOverThrowStubbornInstances} will
-   * be called after the grace period.
+   * One reconciler pass, rescheduled forever until {@link #stop}:
+   *
+   * 1. Heartbeat this instance's liveness.
+   * 2. Declare siblings with a stale heartbeat dead (marks them dying; their
+   *    own death-note poll makes them shut down).
+   * 3. Pause charts and release deferred-event locks whose owner is not a
+   *    live instance, putting them up for adoption.
+   * 4. Gently adopt paused charts with no ongoing activities. Stubborn
+   *    paused charts are force-adopted by
+   *    {@link #forciblyOverThrowStubbornInstances} after the grace period.
+   *
+   * Running continuously (not only during startup) is what makes a rolling
+   * deploy work: the successor is already serving when the predecessor
+   * drains, and picks up its paused charts within one cycle.
    *
    * @private
    */
@@ -124,50 +143,66 @@ export class XJogStartupManager {
 
     this.adoptionLoopTimer = null;
 
-    trace({ message: 'Adopting charts' });
-    const adoptedChartIdentifiers =
-      await this.xJog.persistence.gentlyAdoptCharts(this.xJog.id, cid);
+    try {
+      await this.xJog.persistence.heartbeatInstance(this.xJog.id);
+      await this.xJog.persistence.markStaleInstancesDying(
+        this.xJog.id,
+        this.options.instanceStaleness,
+        cid,
+      );
+      await this.xJog.persistence.releaseOrphanedDeferredEvents(cid);
+      await this.xJog.persistence.pauseOrphanedCharts(cid);
 
-    const pausedChartCount =
-      await this.xJog.persistence.getPausedChartCount(cid);
+      trace({ message: 'Adopting charts' });
+      const adoptedChartIdentifiers =
+        await this.xJog.persistence.gentlyAdoptCharts(this.xJog.id, cid);
 
-    if (adoptedChartIdentifiers.length) {
-      trace({
-        message: 'Starting adopted charts',
-        count: adoptedChartIdentifiers.length,
-        left: pausedChartCount,
-      });
+      const pausedChartCount =
+        await this.xJog.persistence.getPausedChartCount(cid);
 
-      await this.startAdoptedCharts(adoptedChartIdentifiers);
-    } else {
-      trace({
-        message: 'Could not adopt any charts',
-        count: adoptedChartIdentifiers.length,
-        left: pausedChartCount,
+      if (adoptedChartIdentifiers.length) {
+        trace({
+          message: 'Starting adopted charts',
+          count: adoptedChartIdentifiers.length,
+          left: pausedChartCount,
+        });
+
+        await this.startAdoptedCharts(adoptedChartIdentifiers);
+      }
+
+      if (pausedChartCount > 0) {
+        trace({ message: 'More charts to adopt', pausedChartCount });
+
+        // Bug fix: only start the grace period if one isn't already running.
+        // Previously this was called on every adoption cycle (~every 2s),
+        // which cleared and reset the 30s timer each time, preventing
+        // forciblyOverThrowStubbornInstances() from ever firing.
+        if (!this.startupGracePeriodTimer) {
+          this.startAdoptionGracePeriod();
+        }
+      } else {
+        this.exitAdoptionGracePeriod();
+        this.signalReadiness();
+      }
+    } catch (error) {
+      // The reconciler must survive transient database errors; the next
+      // cycle retries the whole pass.
+      this.xJog.error({
+        cid,
+        in: 'startupManager.adoptCharts',
+        message: 'Reconciler pass failed',
+        error:
+          error instanceof Error
+            ? { name: error.name, message: error.message, stack: error.stack }
+            : error,
       });
     }
 
-    if (pausedChartCount > 0) {
-      trace({ message: 'More charts to adopt', pausedChartCount });
-
-      // Bug fix: only start the grace period if one isn't already running.
-      // Previously this was called on every adoption cycle (~every 2s),
-      // which cleared and reset the 30s timer each time, preventing
-      // forciblyOverThrowStubbornInstances() from ever firing.
-      if (!this.startupGracePeriodTimer) {
-        this.startAdoptionGracePeriod();
-      }
-
+    if (!this.stopping) {
       this.adoptionLoopTimer = setTimeout(
         this.adoptCharts.bind(this),
         this.options.adoptionFrequency,
       );
-    } else {
-      trace({ message: 'No more charts to adopt' });
-      this.exitAdoptionGracePeriod();
-
-      trace({ message: 'Signal readiness' });
-      this.signalReadiness();
     }
 
     trace({ message: 'Done' });
@@ -252,6 +287,12 @@ export class XJogStartupManager {
   }
 
   private signalReadiness(): void {
+    // Idempotent: the reconciler reaches the "nothing to adopt" branch on
+    // every quiet cycle, but readiness is only signalled once.
+    if (this.isReady) {
+      return;
+    }
+
     this.isReady = true;
     this.xJog.emit('ready');
 

--- a/packages/digest-persistence/package.json
+++ b/packages/digest-persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-digest-persistence",
-  "version": "0.0.43",
+  "version": "0.0.44",
   "description": "XJog chart digest persistence adapter",
   "engines": {
     "npm": ">=8.19.4",

--- a/packages/digest-pg/package.json
+++ b/packages/digest-pg/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@samihult/xjog-digest-pg",
-	"version": "0.0.136",
+	"version": "0.0.137",
 	"description": "XJog Postgres digest persistence",
 	"engines": {
 		"npm": ">=8.19.4",

--- a/packages/digest-pglite/package.json
+++ b/packages/digest-pglite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-digest-pglite",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Digest package with PGlite backend",
   "author": "Juha Mustonen <juha.mustonen@iki.fi>",
   "homepage": "",

--- a/packages/digest-reader/package.json
+++ b/packages/digest-reader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-digest-reader",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "description": "XJog chart digest reader",
   "engines": {
     "npm": ">=8.19.4",

--- a/packages/digest-writer/package.json
+++ b/packages/digest-writer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@samihult/xjog-digest-writer",
-	"version": "0.0.35",
+	"version": "0.0.36",
 	"description": "XJog chart digest writer",
 	"engines": {
 		"npm": ">=8.19.4",

--- a/packages/journal-persistence/package.json
+++ b/packages/journal-persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-journal-persistence",
-  "version": "0.0.71",
+  "version": "0.0.72",
   "description": "XJog chart abstract journal persistence adapter",
   "engines": {
     "npm": ">=8.19.4",

--- a/packages/journal-pg/package.json
+++ b/packages/journal-pg/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@samihult/xjog-journal-pg",
-	"version": "0.0.136",
+	"version": "0.0.137",
 	"description": "XJog Postgres journaling persistence",
 	"engines": {
 		"npm": ">=8.19.4",

--- a/packages/journal-pglite/package.json
+++ b/packages/journal-pglite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-journal-pglite",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "> TODO: description",
   "author": "Juha Mustonen <juha.mustonen@iki.fi>",
   "homepage": "",

--- a/packages/journal-reader/package.json
+++ b/packages/journal-reader/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@samihult/xjog-journal-reader",
-	"version": "0.0.76",
+	"version": "0.0.77",
 	"description": "XJog chart journal reader",
 	"engines": {
 		"npm": ">=8.19.4",

--- a/packages/journal-writer/package.json
+++ b/packages/journal-writer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-journal-writer",
-  "version": "0.0.92",
+  "version": "0.0.93",
   "description": "XJog chart journal writer",
   "engines": {
     "npm": ">=8.19.4",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-util",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "description": "XJog utils",
   "engines": {
     "npm": ">=8.19.4",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,22 @@
 packages:
   - 'packages/*'
+
+# pnpm 11: settings moved here from the package.json "pnpm" field,
+# which is no longer read. https://pnpm.io/settings
+overrides:
+  'ansi-regex@>=5.0.0 <5.0.1': 5.0.1
+  minimist: ^1.2.6
+  shell-quote: ^1.7.3
+  tmp: '>=0.2.7'
+  form-data: '>=4.0.6'
+  tar: '>=7.5.16'
+  piscina: '>=4.9.3'
+  undici: '>=6.27.0'
+  js-yaml: '>=4.2.0'
+
+# pnpm 11 replaced onlyBuiltDependencies with allowBuilds.
+allowBuilds:
+  '@parcel/watcher': true
+  '@swc/core': true
+  nx: true
+  unrs-resolver: true


### PR DESCRIPTION
# Live handoff between instances + pnpm 11

## Why

Two instances sharing one Postgres could not overlap safely, so
checkout-controller runs `replicas: 1` and every deploy is effectively a
serial restart with a boot-length outage. The blocker was in the engine, not
the app: on startup an instance stages an ownership coup (marks every other
instance dying, pauses **all** charts, adopts them) — and it does this at the
*start* of a multi-minute rehydrate, while the old instance is still serving
100% of traffic and has no idea it was overthrown. `onDeathNote`, the
mechanism meant to tell it, is dead code. Chart writes have no ownership
fence. Result: a wide window every deploy where both instances believe they
own the same charts, last-write-wins.

This makes the handoff correct so a successor can boot *beside* a serving
instance and take over only when that instance drains. It does not add
active-active throughput (the in-process `changeSubject` still means
subscriptions only see local charts) — but a rolling deploy and a hot standby
now work.

## What changed

**`onDeathNote` actually fires.** The poll set `cancelled = true` and then
called the callback inside `if (!cancelled)` — unreachable. An overthrown
instance never learned it was dying. Fixed in both the pg and pglite adapters,
with a post-await re-check so a cancel or a parallel poll can't double-deliver.

**Non-violent boot.** `XJog.start()` now calls `registerInstance` instead of
`overthrowOtherInstances`: it registers itself and adopts only charts that are
actually up for adoption. A booting successor no longer pauses a live sibling's
charts, so in a normal deploy the first adoption pass is empty and the server
binds without waiting on a mass rehydrate. The old coup method is left in place
but unused.

**The adoption loop becomes a continuous reconciler.** Previously it ran only
during startup. Now each pass (every `adoptionFrequency`):

- heartbeats this instance's row (`instances.timestamp` doubles as the
  heartbeat — no schema migration),
- marks siblings whose heartbeat is older than `startup.instanceStaleness`
  (new option, default 60s) as dying,
- releases deferred-event locks and pauses charts whose owner is no longer a
  live instance,
- adopts the paused charts.

Running continuously is what makes the handoff work: the successor is already
serving when the predecessor drains and picks up its charts within a cycle.

**Adoption claims are atomic.** Both gentle and forced adoption now claim
per-chart with `UPDATE ... WHERE paused = TRUE` (gentle additionally requires
no ongoing activities). Two instances reconciling concurrently cannot both win
the same chart.

**Shutdown hands charts over.** `XJog.shutdown()` pauses its own charts so a
live sibling's reconciler adopts them, and — importantly — stops the reconciler
*before* deregistering. Otherwise a dying instance's own reconciler would see
its now-orphaned charts, pause them, and claim them straight back, fighting the
successor. (This also fixes a latent bug: shutdown only stopped the loop when
boot was still incomplete.)

**Ownership fencing on writes.** Chart-state writes carry `AND ownerId = me`.
A fenced-off write throws `ChartOwnershipLostError`; `send()` catches it,
returns null, and evicts the stale in-memory copy so the next read reloads the
owner's state. Backstop for any residual overlap — it loses gracefully instead
of silently clobbering.

**PGlite bytea fix.** Reloading a chart went through `Uint8Array.toString()`,
which yields comma-joined byte values, not JSON. Decode via `Buffer` so a chart
can actually round-trip through the pglite adapter (surfaced by the fencing
test, which is the first to reload a chart after a foreign write).

## Deploy sequence this enables

New pod boots fast (nothing to adopt) → goes SERVING → Kubernetes marks it
Ready and terminates the old pod → old pod drains gRPC, pauses its charts,
exits → new pod's reconciler adopts within a cycle. Downtime approaches the
gRPC reconnect window instead of a full boot.

## Also in here: pnpm 11

Aligns the toolchain with the consuming repo (both now pin `pnpm@11.9.0`):

- `packageManager` → `pnpm@11.9.0`, engines → `>=11.0.0`.
- pnpm 11 no longer reads the `pnpm` field in package.json, so `overrides`
  moved to `pnpm-workspace.yaml` and `onlyBuiltDependencies` became the
  `allowBuilds` map.
- `.npmrc` default registry points at the public npm registry; the `@samihult`
  scope resolves from GitHub Packages. pnpm 11 verifies lockfile entries
  against the registry at install time, which 404s against a
  publish-only/local registry — pnpm 10 masked this by never re-fetching.
- Dropped the `PNPM_VERSION` pin from the CI workflow so
  `pnpm/action-setup@v5` reads the version from `packageManager` (having both
  is a hard error).

## Testing

Full suite green under pnpm 11 (build + lint + 85 tests across 15 packages),
including new coverage for every primitive above and two end-to-end scenarios:
a rolling handoff between two live instances against one database, and a
shutdown that must stop its reconciler so it can't re-claim its own charts.

## Versions

All packages patch-bumped (`@samihult/xjog` 0.0.339 → 0.0.340, `xjog-core-pg`
0.0.82 → 0.0.83, etc.).

## Follow-ups (consuming repo, not here)

- Publish and re-pin.
- Wire `startup.instanceStaleness` into the controller config (60s default is
  probably right given known event-loop stalls, but it should be a conscious
  choice).
- Exercise the gRPC client's resubscribe-on-reconnect during a handoff.
