### PR TITLE
Surface chart ownership loss as a distinct, catchable error

### DIFF
--- a/packages/core-persistence/package.json
+++ b/packages/core-persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-core-persistence",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "description": "XJog chart abstract persistence",
   "engines": {
     "npm": ">=8.19.4",

--- a/packages/core-persistence/src/PersistenceAdapter.ts
+++ b/packages/core-persistence/src/PersistenceAdapter.ts
@@ -40,6 +40,18 @@ export class ChartOwnershipLostError extends Error {
     );
     this.name = 'ChartOwnershipLostError';
   }
+
+  /**
+   * Name-based type guard. Package managers can resolve two copies of this
+   * package into one dependency tree, and `instanceof` fails across copies —
+   * match on the error name so consumers can rely on the check.
+   */
+  public static is(error: unknown): error is ChartOwnershipLostError {
+    return (
+      error instanceof ChartOwnershipLostError ||
+      (error instanceof Error && error.name === 'ChartOwnershipLostError')
+    );
+  }
 }
 
 /**
@@ -415,7 +427,7 @@ export abstract class PersistenceAdapter<
    */
   public abstract releaseDeferredEvent(
     ref: ChartReference,
-    eventId: number,
+    eventId: string | number,
     connection?: ConnectionType,
   ): Promise<void>;
 

--- a/packages/core-pg/package.json
+++ b/packages/core-pg/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@samihult/xjog-core-pg",
-	"version": "0.0.83",
+	"version": "0.0.84",
 	"description": "XJog chart Postgres persistence",
 	"engines": {
 		"npm": ">=8.19.4",

--- a/packages/core-pglite/package.json
+++ b/packages/core-pglite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-core-pglite",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "Lightweight PG adapter",
   "keywords": [
     "pg"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@samihult/xjog",
-	"version": "0.0.340",
+	"version": "0.0.341",
 	"description": "XState chart runner for long-running charts",
 	"engines": {
 		"npm": ">=8.19.4",

--- a/packages/core/src/XJogChart.test.ts
+++ b/packages/core/src/XJogChart.test.ts
@@ -527,9 +527,9 @@ describe('ChartOwnershipLostError.is', () => {
   const ref = { machineId: 'm', chartId: 'c' };
 
   it('recognizes a real instance', () => {
-    expect(ChartOwnershipLostError.is(new ChartOwnershipLostError(ref, 'i'))).toBe(
-      true,
-    );
+    expect(
+      ChartOwnershipLostError.is(new ChartOwnershipLostError(ref, 'i')),
+    ).toBe(true);
   });
 
   it('recognizes a same-named error from a duplicated package instance', () => {

--- a/packages/core/src/XJogChart.test.ts
+++ b/packages/core/src/XJogChart.test.ts
@@ -1,4 +1,5 @@
 import { PGlitePersistenceAdapter } from '@samihult/xjog-core-pglite';
+import { ChartOwnershipLostError } from '@samihult/xjog-core-persistence';
 import { Subject } from 'rxjs';
 import { createMachine, interpret, State } from 'xstate';
 
@@ -489,9 +490,17 @@ describe('XJogChart: ownership fencing on state writes', () => {
       await client.query('UPDATE "charts" SET "ownerId" = $1', ['usurper']);
     });
 
-    // The fenced write must not go through; send reports failure with null.
-    const result = await chart.send('go');
-    expect(result).toBeNull();
+    // The fenced write must not go through. Ownership loss is an expected,
+    // self-correcting handoff condition, so send() surfaces it as a DISTINCT
+    // error — not the generic null — letting callers skip failure accounting
+    // and ask their client to retry.
+    let thrown: unknown;
+    try {
+      await chart.send('go');
+    } catch (error) {
+      thrown = error;
+    }
+    expect(ChartOwnershipLostError.is(thrown)).toBe(true);
 
     // The persisted state is untouched — still the owner's version.
     const persisted = await persistence.withTransaction(async (client) =>
@@ -511,5 +520,30 @@ describe('XJogChart: ownership fencing on state writes', () => {
     await new Promise((resolve) => setTimeout(resolve, 100));
     const reloaded = await xJogMachine.getChart(chart.id);
     expect(reloaded).not.toBe(chart);
+  });
+});
+
+describe('ChartOwnershipLostError.is', () => {
+  const ref = { machineId: 'm', chartId: 'c' };
+
+  it('recognizes a real instance', () => {
+    expect(ChartOwnershipLostError.is(new ChartOwnershipLostError(ref, 'i'))).toBe(
+      true,
+    );
+  });
+
+  it('recognizes a same-named error from a duplicated package instance', () => {
+    // pnpm can resolve two copies of xjog-core-persistence into a consumer's
+    // tree; instanceof fails across them, so the guard matches by name.
+    const foreign = new Error('lost');
+    foreign.name = 'ChartOwnershipLostError';
+    expect(ChartOwnershipLostError.is(foreign)).toBe(true);
+  });
+
+  it('rejects other errors and non-errors', () => {
+    expect(ChartOwnershipLostError.is(new Error('nope'))).toBe(false);
+    expect(ChartOwnershipLostError.is(null)).toBe(false);
+    expect(ChartOwnershipLostError.is(undefined)).toBe(false);
+    expect(ChartOwnershipLostError.is('ChartOwnershipLostError')).toBe(false);
   });
 });

--- a/packages/core/src/XJogChart.ts
+++ b/packages/core/src/XJogChart.ts
@@ -832,19 +832,24 @@ export class XJogChart<
           },
         );
       } catch (err) {
-        if (err instanceof ChartOwnershipLostError) {
+        if (ChartOwnershipLostError.is(err)) {
           // A sibling adopted this chart (deploy handoff or stale-instance
           // takeover). The in-memory copy is stale; evict it so the next
           // getChart reloads the owner's state from the database. Eviction
           // waits for this send's mutex to release, so it must not be
           // awaited here.
+          //
+          // Rethrown rather than swallowed to null: ownership loss is an
+          // expected, self-correcting handoff condition, and callers need to
+          // tell it apart from a genuine send failure (retry / redirect
+          // instead of counting it against service health).
           error('Chart ownership lost, dropping the local copy', { err });
           this.xJogMachine
             .evictCacheEntry(this.id)
             .catch((evictError) =>
               error('Failed to evict chart from cache', { err: evictError }),
             );
-          return null;
+          throw err;
         }
 
         error('Failed to send event, returning null', { err });

--- a/packages/core/src/XJogDeferredEventManager.test.ts
+++ b/packages/core/src/XJogDeferredEventManager.test.ts
@@ -1,7 +1,10 @@
 import { toSCXMLEvent } from 'xstate/lib/utils';
 
 import { PGlitePersistenceAdapter } from '@samihult/xjog-core-pglite';
-import { PersistenceAdapter } from '@samihult/xjog-core-persistence';
+import {
+  ChartOwnershipLostError,
+  PersistenceAdapter,
+} from '@samihult/xjog-core-persistence';
 import { waitFor } from '@samihult/xjog-util';
 
 import { XJogDeferredEventManager } from './XJogDeferredEventManager';
@@ -682,5 +685,54 @@ describe('XJogDeferredEventManager', () => {
         await deferredEventManager.releaseAll();
       }
     });
+  });
+});
+
+describe('XJogDeferredEventManager: ownership loss during deferred send', () => {
+  it('unlocks the event for the owner instead of removing or keeping it locked', async () => {
+    const persistence = createInMemoryPersistence();
+    (persistence as any).releaseDeferredEvent = jest.fn(async () => {});
+
+    // Short interval like the other tests: a leftover read timer fires once,
+    // sees the dying flag set in the finally block, and stops — keeping the
+    // event loop clean so jest can exit.
+    const [xJog, deferredEventManager] = mockXJogWithDeferredEventManager(
+      persistence,
+      { batchSize: 5, lookAhead: 20, interval: 30 },
+    );
+
+    const ref = { machineId: 'A', chartId: '1' };
+    const ownershipLost = new ChartOwnershipLostError(ref, 'xjog-id');
+    (xJog.sendEvent as jest.Mock).mockRejectedValue(ownershipLost);
+
+    try {
+      await deferredEventManager.defer({
+        eventId: 'e-7',
+        ref,
+        event: toSCXMLEvent('due now'),
+        delay: 0,
+      });
+
+      // Read the due event and fire its timer.
+      await deferredEventManager.scheduleUpcoming();
+      await waitFor(50);
+
+      expect(xJog.sendEvent).toHaveBeenCalled();
+
+      // The chart belongs to another live instance now. This instance must
+      // hand the event back (lock=NULL) so the owner's deferred loop can
+      // fire it -- the reconciler only unlocks events of DEAD instances, so
+      // keeping the lock would strand the timer forever.
+      expect((persistence as any).releaseDeferredEvent).toHaveBeenCalledWith(
+        ref,
+        'e-7',
+      );
+      // And it must NOT be treated as delivered.
+      expect(persistence.removeDeferredEvent).not.toHaveBeenCalled();
+    } finally {
+      // @ts-ignore test-only shutdown flag
+      xJog.dying = true;
+      await deferredEventManager.releaseAll();
+    }
   });
 });

--- a/packages/core/src/XJogDeferredEventManager.ts
+++ b/packages/core/src/XJogDeferredEventManager.ts
@@ -1,5 +1,8 @@
 import { randomUUID } from 'node:crypto';
-import { PersistedDeferredEvent } from '@samihult/xjog-core-persistence';
+import {
+  ChartOwnershipLostError,
+  PersistedDeferredEvent,
+} from '@samihult/xjog-core-persistence';
 
 import {
   getCorrelationIdentifier,
@@ -319,6 +322,42 @@ export class XJogDeferredEventManager {
           }
         }
       } catch (error) {
+        if (ChartOwnershipLostError.is(error)) {
+          // The chart was adopted by another live instance while this event
+          // was in flight. Hand the event back (lock=NULL) so the owner's
+          // deferred loop can fire it — the reconciler only releases locks
+          // of DEAD instances, so keeping our lock would strand the timer
+          // forever. Not treated as delivered: the persisted row stays.
+          trace({
+            level: 'warning',
+            message: 'Chart ownership lost, releasing the event to its owner',
+            error,
+          });
+
+          try {
+            await this.xJog.persistence.releaseDeferredEvent(
+              persistedDeferredEvent.ref,
+              persistedDeferredEvent.eventId,
+            );
+          } catch (releaseError) {
+            trace({
+              level: 'error',
+              message: 'Failed to release the deferred event',
+              error: releaseError,
+            });
+          }
+
+          const eventIndex = this.deferredEvents.findIndex(
+            (candidate) => candidate.id === persistedDeferredEvent.id,
+          );
+          if (eventIndex >= 0) {
+            this.deferredEvents.splice(eventIndex, 1);
+          }
+
+          this.deferredEventTimers.delete(persistedDeferredEvent.id);
+          return;
+        }
+
         // A rejected send (e.g. a chart mutex acquire timeout) must not become
         // an unhandled rejection. Skip the cleanup: the persisted event stays
         // in place, so the next instance retries it on boot.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,9 @@
 export { State } from 'xstate';
 
+// Re-exported so consumers can catch ownership loss from chart.send()
+// without depending on xjog-core-persistence directly.
+export { ChartOwnershipLostError } from '@samihult/xjog-core-persistence';
+
 export * from './XJog';
 export * from './XJogMachine';
 export * from './XJogChart';

--- a/packages/digest-persistence/package.json
+++ b/packages/digest-persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-digest-persistence",
-  "version": "0.0.44",
+  "version": "0.0.45",
   "description": "XJog chart digest persistence adapter",
   "engines": {
     "npm": ">=8.19.4",

--- a/packages/digest-pg/package.json
+++ b/packages/digest-pg/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@samihult/xjog-digest-pg",
-	"version": "0.0.137",
+	"version": "0.0.138",
 	"description": "XJog Postgres digest persistence",
 	"engines": {
 		"npm": ">=8.19.4",

--- a/packages/digest-pglite/package.json
+++ b/packages/digest-pglite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-digest-pglite",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "Digest package with PGlite backend",
   "author": "Juha Mustonen <juha.mustonen@iki.fi>",
   "homepage": "",

--- a/packages/digest-reader/package.json
+++ b/packages/digest-reader/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-digest-reader",
-  "version": "0.0.49",
+  "version": "0.0.50",
   "description": "XJog chart digest reader",
   "engines": {
     "npm": ">=8.19.4",

--- a/packages/digest-writer/package.json
+++ b/packages/digest-writer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@samihult/xjog-digest-writer",
-	"version": "0.0.36",
+	"version": "0.0.37",
 	"description": "XJog chart digest writer",
 	"engines": {
 		"npm": ">=8.19.4",

--- a/packages/journal-persistence/package.json
+++ b/packages/journal-persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-journal-persistence",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "description": "XJog chart abstract journal persistence adapter",
   "engines": {
     "npm": ">=8.19.4",

--- a/packages/journal-pg/package.json
+++ b/packages/journal-pg/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@samihult/xjog-journal-pg",
-	"version": "0.0.137",
+	"version": "0.0.138",
 	"description": "XJog Postgres journaling persistence",
 	"engines": {
 		"npm": ">=8.19.4",

--- a/packages/journal-pglite/package.json
+++ b/packages/journal-pglite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-journal-pglite",
-  "version": "0.0.21",
+  "version": "0.0.22",
   "description": "> TODO: description",
   "author": "Juha Mustonen <juha.mustonen@iki.fi>",
   "homepage": "",

--- a/packages/journal-reader/package.json
+++ b/packages/journal-reader/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@samihult/xjog-journal-reader",
-	"version": "0.0.77",
+	"version": "0.0.78",
 	"description": "XJog chart journal reader",
 	"engines": {
 		"npm": ">=8.19.4",

--- a/packages/journal-writer/package.json
+++ b/packages/journal-writer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-journal-writer",
-  "version": "0.0.93",
+  "version": "0.0.94",
   "description": "XJog chart journal writer",
   "engines": {
     "npm": ">=8.19.4",

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@samihult/xjog-util",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "description": "XJog utils",
   "engines": {
     "npm": ">=8.19.4",


### PR DESCRIPTION
# Surface chart ownership loss as a distinct, catchable error

## Why

Field finding from the first live-handoff (0.0.340) rolling deploy: during the
handoff window, events for charts still owned by the draining predecessor land
on the successor and get correctly fenced — but `send()` swallowed the fence to
the same `null` as any genuine failure. The consuming service counts null sends
against its event-error health circuit, so the freshly adopted pod flipped its
gRPC health to NOT_SERVING and was **liveness-killed mid-handoff**, leaving a
brief window with no serving pod. The fence is expected, self-correcting
deploy behaviour; callers just had no way to tell it apart.

## What changed

- **`XJogChart.send()` rethrows `ChartOwnershipLostError`** (after evicting the
  stale cache entry, as before) instead of returning null. All other failures
  keep the existing null contract. Callers can now branch: skip failure
  accounting, ask the client to retry — by then the reconciler has adopted the
  chart.
- **`ChartOwnershipLostError.is()`** name-based type guard. Package managers
  can resolve two copies of `xjog-core-persistence` into one tree and
  `instanceof` fails across copies; the guard matches by error name.
- **Deferred-event manager releases fenced events back to the owner.** When a
  deferred send is fenced, the event's lock is set back to NULL so the chart's
  new owner can fire it. Keeping the lock would strand the timer forever: the
  lock holder is alive, and the reconciler only releases locks of dead
  instances.

## Not changed

- Sends that fail for any other reason still resolve to null (existing
  contract).
- No behaviour change when ownership is intact.

## Testing

Full suite green (89 tests across 15 packages): updated fencing test expects
the rejection; new guard tests (real instance, duplicated-package lookalike,
negatives); new deferred-manager test asserts the fenced event is unlocked and
not treated as delivered.

## Versions

All packages patch-bumped (`@samihult/xjog` 0.0.340 → 0.0.341, etc.).

## Consumer follow-up (separate PR in the consuming repo)

Handlers branch on `ChartOwnershipLostError.is(err)`: skip the health-circuit
counter, respond gRPC UNAVAILABLE (retryable); the Kafka dispatcher must not
commit the offset on a fenced send so the status update is retried after
adoption.
