### PR TITLE
Upgrade xstate to 4.38.3 (latest v4)

### DIFF
--- a/packages/core-persistence/package.json
+++ b/packages/core-persistence/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@samihult/xjog-util": "workspace:^",
-    "xstate": "4.26.1"
+    "xstate": "4.38.3"
   },
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
 }

--- a/packages/core-pg/package.json
+++ b/packages/core-pg/package.json
@@ -36,7 +36,7 @@
 		"pg-bind": "^1.0.1",
 		"pg-listen": "^1.7.0",
 		"rfc6902": "^5.0.1",
-		"xstate": "4.26.1"
+		"xstate": "4.38.3"
 	},
 	"devDependencies": {
 		"@types/pg": "8.20.0"

--- a/packages/core-pglite/package.json
+++ b/packages/core-pglite/package.json
@@ -31,7 +31,7 @@
     "@samihult/xjog-core-persistence": "workspace:^",
     "@samihult/xjog-util": "workspace:^",
     "node-pg-migrate": "^6.2.1",
-    "xstate": "4.26.1"
+    "xstate": "4.38.3"
   },
   "devDependencies": {},
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
 		"@samihult/xjog-core-persistence": "workspace:^",
 		"@samihult/xjog-util": "workspace:^",
 		"async-mutex": "^0.3.2",
-		"xstate": "4.26.1"
+		"xstate": "4.38.3"
 	},
 	"devDependencies": {
 		"@samihult/xjog-core-pglite": "workspace:^",

--- a/packages/core/src/XJogChart.ts
+++ b/packages/core/src/XJogChart.ts
@@ -17,10 +17,13 @@ import { Mutex, type MutexInterface, withTimeout } from 'async-mutex';
 import { concat, filter, from, map, type Observable, of } from 'rxjs';
 import {
   type ActionObject,
+  type ActionFunction,
   ActionTypes,
+  type BaseActionObject,
   type ActivityActionObject,
   type AnyEventObject,
   type CancelAction,
+  type LogActionObject,
   type DelayFunctionMap,
   type Event,
   type EventObject,
@@ -350,16 +353,18 @@ export class XJogChart<
     xJogMachine: XJogMachine<TContext, TStateSchema, TEvent, TTypeState>,
     chartId: string,
     state: State<TContext, TEvent, TStateSchema, TTypeState>,
-  ): Promise<Array<ActionObject<TContext, TEvent>>> {
+  ): Promise<Array<SendActionObject<TContext, TEvent>>> {
     const afterActions = state.configuration.flatMap((stateNode) =>
       XJogChart.resolveAfterActionsForStateNode(
         stateNode,
-        xJogMachine.machine.options.delays,
+        xJogMachine.machine.options.delays as
+          | DelayFunctionMap<TContext, TEvent>
+          | undefined,
         state.context,
       ),
     );
 
-    const missingAfterActions: Array<ActionObject<TContext, TEvent>> = [];
+    const missingAfterActions: Array<SendActionObject<TContext, TEvent>> = [];
 
     for (const action of afterActions) {
       if (!action.id) {
@@ -443,7 +448,7 @@ export class XJogChart<
     stateNode: StateNode<TContext, any, TEvent>,
     delays: DelayFunctionMap<TContext, TEvent> | undefined,
     context: TContext,
-  ): Array<ActionObject<TContext, TEvent>> {
+  ): Array<SendActionObject<TContext, TEvent>> {
     return stateNode.after
       .map((transition) => ({
         transition,
@@ -468,7 +473,7 @@ export class XJogChart<
             delay: resolvedDelay as number,
             event: { type: transition.eventType },
             _event: toSCXMLEvent({ type: transition.eventType }),
-          }) as ActionObject<TContext, TEvent>,
+          }) as SendActionObject<TContext, TEvent>,
       );
   }
 
@@ -989,10 +994,15 @@ export class XJogChart<
       const actionOrExec =
         action.exec || getActionFunction(action.type, machine.options.actions);
 
+      // The `isFunction` guard is a runtime check: action objects are plain
+      // objects, so they fall through to the `.exec` lookup. The casts are
+      // needed because xstate 4.38's ActionObject type declares a phantom
+      // call signature (a TS inference aid that doesn't exist at runtime),
+      // which makes the narrowing collapse the object branch to `never`.
       const exec = isFunction(actionOrExec)
-        ? actionOrExec
+        ? (actionOrExec as ActionFunction<TContext, TEvent>)
         : actionOrExec
-          ? actionOrExec.exec
+          ? (actionOrExec as ActionObject<TContext, TEvent>).exec
           : action.exec;
 
       // If it's immediately executable, run it...
@@ -1017,7 +1027,11 @@ export class XJogChart<
           await this.xJog.timeExecution(
             'chart.execute action.send',
             async () => {
-              const delay = action.delay ?? 0;
+              const sendAction = action as unknown as SendActionObject<
+                TContext,
+                TEvent
+              >;
+              const delay = sendAction.delay ?? 0;
 
               const PersistedDeferredEvent: Omit<
                 PersistedDeferredEvent,
@@ -1026,11 +1040,15 @@ export class XJogChart<
                 eventId: string | number;
               } = {
                 ref: this.ref,
-                event: action._event,
+                event: sendAction._event,
                 // TODO what should we send as eventId
-                eventId: action.id ?? randomUUID(),
+                eventId: sendAction.id ?? randomUUID(),
                 // TODO should we also send actionId and sendId?
-                eventTo: action.to ?? null,
+                eventTo: (sendAction.to ?? null) as
+                  | string
+                  | number
+                  | ActivityRef
+                  | null,
                 delay,
                 lock: null,
               };
@@ -1061,7 +1079,7 @@ export class XJogChart<
           await this.xJog.timeExecution(
             'chart.execute action.cancel',
             async () => {
-              const sendId = (action as CancelAction).sendId;
+              const sendId = (action as CancelAction<TContext, TEvent>).sendId;
               trace({ message: 'Canceling event', sendId });
               await this.xJog.deferredEventManager.cancel(
                 sendId,
@@ -1090,7 +1108,15 @@ export class XJogChart<
                 // Invoked services
                 if (activity.type === ActionTypes.Invoke) {
                   trace({ message: 'Invoking service', activityId });
-                  await this.invokeService(action.id, state, activity, cid);
+                  // `id` is not part of the ActivityActionObject type, but
+                  // xstate attaches it at runtime; BaseActionObject keeps the
+                  // permissive index signature that ActionObject had in 4.26.
+                  await this.invokeService(
+                    (action as unknown as BaseActionObject).id,
+                    state,
+                    activity,
+                    cid,
+                  );
                 }
 
                 // Spawn
@@ -1135,7 +1161,10 @@ export class XJogChart<
 
         case ActionTypes.Log: {
           await this.xJog.timeExecution('chart.execute action.log', () => {
-            const { label, value } = action;
+            const { label, value } = action as LogActionObject<
+              TContext,
+              TEvent
+            >;
             const message = isFunction(value) ? value() : value;
             this.info(message, { label });
           });
@@ -1591,10 +1620,16 @@ export class XJogChart<
     machine: StateMachine<TChildContext, TChildStateSchema, TChildEvent>,
     options: SpawnOptions,
   ): Promise<ActivityRef> {
+    // The trailing `any` (resolved typegen meta) keeps the declaration
+    // assignable from `new Interpreter(machine)`, whose machine carries the
+    // default ResolveTypegenMeta while a bare Interpreter<...> defaults to
+    // TypegenDisabled.
     let childService: Interpreter<
       TChildContext,
       TChildStateSchema,
-      TChildEvent
+      TChildEvent,
+      { value: any; context: TChildContext },
+      any
     > | null = null;
 
     // const observers = new Set<Observer<EventObject>>();

--- a/packages/core/src/XJogMachine.ts
+++ b/packages/core/src/XJogMachine.ts
@@ -64,11 +64,18 @@ export class XJogMachine<
 
   public constructor(
     public readonly xJog: XJog,
+    // The last three parameters (action, service map, resolved typegen meta)
+    // are left as `any` so that machines built by any typegen mode remain
+    // assignable, and so that states produced by this machine stay compatible
+    // with the plain four-parameter `State<...>` signatures used across xjog.
     public readonly machine: StateMachine<
       TContext,
       TStateSchema,
       TEvent,
-      TTypeState
+      TTypeState,
+      any,
+      any,
+      any
     >,
     options?: XJogMachineOptions,
   ) {

--- a/packages/core/src/resolveXJogStateChange.ts
+++ b/packages/core/src/resolveXJogStateChange.ts
@@ -53,7 +53,10 @@ function mapState<
   return {
     value: clone ? structuredClone(state.value) : state.value,
     context: clone ? structuredClone(state.context) : state.context,
-    actions: mapActions(state.actions),
+    // ActionObject lost its permissive index signatures in xstate 4.38, so it
+    // no longer satisfies BaseActionObject structurally; at runtime the
+    // resolved actions are the same plain objects they were in 4.26.
+    actions: mapActions(state.actions as unknown as BaseActionObject[]),
   };
 }
 

--- a/packages/journal-persistence/package.json
+++ b/packages/journal-persistence/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@samihult/xjog-util": "workspace:^",
     "rfc6902": "^5.0.1",
-    "xstate": "4.26.1"
+    "xstate": "4.38.3"
   },
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
   "peerDependencies": {

--- a/packages/journal-pglite/package.json
+++ b/packages/journal-pglite/package.json
@@ -25,7 +25,7 @@
     "@samihult/xjog-journal-persistence": "workspace:^",
     "@samihult/xjog-util": "workspace:^",
     "node-pg-migrate": "^6.2.1",
-    "xstate": "4.26.1"
+    "xstate": "4.38.3"
   },
   "devDependencies": {}
 }

--- a/packages/journal-reader/package.json
+++ b/packages/journal-reader/package.json
@@ -36,7 +36,7 @@
 		"pg-bind": "^1.0.1",
 		"pg-listen": "^1.7.0",
 		"rfc6902": "^5.0.1",
-		"xstate": "4.26.1"
+		"xstate": "4.38.3"
 	},
 	"devDependencies": {
 		"@types/pg": "8.20.0"

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "rfc6902": "^5.0.1",
-    "xstate": "4.26.1"
+    "xstate": "4.38.3"
   },
   "devDependencies": {},
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ importers:
         specifier: ^7.8.2
         version: 7.8.2
       xstate:
-        specifier: 4.26.1
-        version: 4.26.1
+        specifier: 4.38.3
+        version: 4.38.3
     devDependencies:
       '@samihult/xjog-core-pglite':
         specifier: workspace:^
@@ -108,8 +108,8 @@ importers:
         specifier: workspace:^
         version: link:../util
       xstate:
-        specifier: 4.26.1
-        version: 4.26.1
+        specifier: 4.38.3
+        version: 4.38.3
 
   packages/core-pg:
     dependencies:
@@ -135,8 +135,8 @@ importers:
         specifier: ^5.0.1
         version: 5.2.0
       xstate:
-        specifier: 4.26.1
-        version: 4.26.1
+        specifier: 4.38.3
+        version: 4.38.3
     devDependencies:
       '@types/pg':
         specifier: 8.20.0
@@ -157,8 +157,8 @@ importers:
         specifier: ^6.2.1
         version: 6.2.2(pg@8.21.0)
       xstate:
-        specifier: 4.26.1
-        version: 4.26.1
+        specifier: 4.38.3
+        version: 4.38.3
 
   packages/digest-persistence:
     dependencies:
@@ -261,8 +261,8 @@ importers:
         specifier: ^7.8.2
         version: 7.8.2
       xstate:
-        specifier: 4.26.1
-        version: 4.26.1
+        specifier: 4.38.3
+        version: 4.38.3
 
   packages/journal-pg:
     dependencies:
@@ -310,8 +310,8 @@ importers:
         specifier: ^6.2.1
         version: 6.2.2(pg@8.21.0)
       xstate:
-        specifier: 4.26.1
-        version: 4.26.1
+        specifier: 4.38.3
+        version: 4.38.3
 
   packages/journal-reader:
     dependencies:
@@ -340,8 +340,8 @@ importers:
         specifier: ^7.8.2
         version: 7.8.2
       xstate:
-        specifier: 4.26.1
-        version: 4.26.1
+        specifier: 4.38.3
+        version: 4.38.3
     devDependencies:
       '@types/pg':
         specifier: 8.20.0
@@ -365,8 +365,8 @@ importers:
         specifier: ^5.0.1
         version: 5.2.0
       xstate:
-        specifier: 4.26.1
-        version: 4.26.1
+        specifier: 4.38.3
+        version: 4.38.3
 
 packages:
 
@@ -2103,6 +2103,7 @@ packages:
   conventional-changelog-core@5.0.1:
     resolution: {integrity: sha512-Rvi5pH+LvgsqGwZPZ3Cq/tz4ty7mjijhr3qR4m9IBXNbxGGYgTVVO+duXzz9aArmHxFtwZ+LRkrNIMDQzgoY4A==}
     engines: {node: '>=14'}
+    deprecated: Deprecated and no longer maintained. Please use conventional-changelog instead.
 
   conventional-changelog-preset-loader@3.0.0:
     resolution: {integrity: sha512-qy9XbdSLmVnwnvzEisjxdDiLA4OmV3o8db+Zdg4WiFw14fP3B6XNz98X0swPPpkTd/pc1K7+adKgEDM1JCUMiA==}
@@ -2613,7 +2614,7 @@ packages:
   git-raw-commits@3.0.0:
     resolution: {integrity: sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==}
     engines: {node: '>=14'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -2623,7 +2624,7 @@ packages:
   git-semver-tags@5.0.1:
     resolution: {integrity: sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA==}
     engines: {node: '>=14'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@7.0.0:
@@ -4461,8 +4462,8 @@ packages:
     resolution: {integrity: sha512-GmqrO8WJ1NuzJ2DrziEI2o57jKAVIQNf8a18W3nCYU3H7PNWqCCVTeH6/NQE93CIllIgQS98rrmVkYgTX9fFJQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
-  xstate@4.26.1:
-    resolution: {integrity: sha512-JLofAEnN26l/1vbODgsDa+Phqa61PwDlxWu8+2pK+YbXf+y9pQSDLRvcYH2H1kkeUBA5fGp+xFL/zfE8jNMw4g==}
+  xstate@4.38.3:
+    resolution: {integrity: sha512-SH7nAaaPQx57dx6qvfcIgqKRXIh4L0A1iYEqim4s1u7c9VoCgzZc+63FY90AKU4ZzOC2cfJzTnpO4zK7fCUzzw==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -9194,7 +9195,7 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
-  xstate@4.26.1: {}
+  xstate@4.38.3: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Summary

Bumps the pinned `xstate` from 4.26.1 (2021) to 4.38.3, the final v4 release, across all packages. All changes outside the version pins are type-level; runtime behavior is untouched.

## Why the type changes

xstate 4.29 retrofitted typegen metadata into `State`/`StateMachine`/`Interpreter` generics, and later 4.3x releases tightened `ActionObject` (removed its permissive string index signature, added a phantom call signature as an inference aid). Since xjog implements its own interpreter on top of these types, that surfaced 27 compile errors in `@samihult/xjog` core:

- **XJogMachine**: the registered machine's action/service-map/typegen type parameters are now `any`, so states produced by the machine stay assignable to the plain four-parameter `State<...>` signatures used across the codebase. This was the single choke point for most of the errors.
- **XJogChart**: action-execution paths narrow to the concrete action object types (`SendActionObject`, `CancelAction<TContext, TEvent>`, `LogActionObject`) instead of relying on the removed index signature. The after-action repair helpers now return `SendActionObject[]`, which is what they construct.
- **isFunction narrowing**: 4.38's `ActionObject` declares a call signature that doesn't exist at runtime, which collapsed the non-function branch to `never`; the existing runtime logic is kept with explicit casts.
- **resolveXJogStateChange**: resolved actions are cast for `mapActions`, which expects `BaseActionObject`.

## Verification

- `lerna run build` — all 15 packages compile
- `lerna run lint` — clean
- `lerna run test` — 77 passed, 3 pre-existing skips
- Cross-version persisted-state compatibility checked empirically with a machine using nested states, `after` delays and an invoked service: states serialized by 4.26.1 rehydrate via `State.create` + `resolveState` under 4.38.3 and continue transitioning correctly (pending after-timers and activities intact), and 4.38.3-serialized states rehydrate under 4.26.1 for rollback.

## Notes

- 4.38 logs a `predictableActionArguments` recommendation on `createMachine` in non-production environments. Enabling that flag changes action-argument ordering semantics, so it is deliberately **not** set here; consumers should not set it blindly either.
- The parked integration suite (`tests-int/`, disabled via `package._json`) did not run; downstream consumers should soak in a dev environment before rolling forward.
- Consumers should bump their own `xstate` pin to 4.38.3 in the same release to avoid two xstate copies in the module graph.