### PR TITLE
Pin publishing to JFrog via publishConfig; retire publish branch

### DIFF
--- a/.changeset/remove-lerna-add-turbo.md
+++ b/.changeset/remove-lerna-add-turbo.md
@@ -16,7 +16,9 @@
 "@samihult/xjog-util": patch
 ---
 
-Build tooling and tests only: replace Lerna with pnpm workspace scripts +
+Build tooling, packaging, and tests. Replace Lerna with pnpm workspace scripts +
 Turborepo, adopt Changesets for versioning/publishing, and silence noisy test
 warnings (xstate `predictableActionArguments`, VM-modules experimental warning,
 an intentional unresolvable-delay warning) plus add PGlite teardown in tests.
+Pin publishing to the JFrog registry via each package's `publishConfig` and point
+`repository`/`homepage` at `telia-oss/xjog`. No runtime code changes.

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,3 @@
-@samihult:registry=https://npm.pkg.github.com
 registry=https://registry.npmjs.org
+@samihult:registry=https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-local/
 engine-strict=true

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -58,20 +58,15 @@ Select the affected packages and the bump level, write a short summary, and comm
 the generated file in `.changeset/` alongside your code. While in alpha, keep bumps as
 `patch` so versions stay `0.0.x`.
 
-To cut a release (maintainers):
+To cut a release, maintainers run `pnpm version-packages` (consume changesets +
+bump) and then `pnpm release` (build + publish) from `main`. Packages publish to
+Telia's JFrog Artifactory, pinned via each package's `publishConfig.registry` and
+the `@samihult:registry` entry in `.npmrc`. The full runbook — auth and
+troubleshooting the "already published / nothing to publish" case — is in
+[releasing.md](./releasing.md).
 
-```bash
-pnpm version-packages   # consume pending changesets: bump versions + write changelogs
-pnpm install            # refresh the lockfile after the bumps
-pnpm release            # build all packages, then publish the changed ones + git tags
-```
-
-While in alpha, packages will be pushed to GitHub packages under the `@samihult` namespace. At graduation, the namespace
-will be converted to `@xjog` and the packages will be transferred to an NpmJs repository. In that phase, the publishing
-will be managed by a GitHub Actions workflow – in the alpha phase it needs to be done manually.
-
-In order to push to the private GitHub packages repository, you will need a personal access token. Ask repository owners
-for access to your GitHub account.
+Publishing is manual during alpha and requires a JFrog auth token in your
+`~/.npmrc` (never committed). See [releasing.md](./releasing.md) for details.
 
 ## Issues and branching
 

--- a/contributing/releasing.md
+++ b/contributing/releasing.md
@@ -1,0 +1,99 @@
+# Releasing
+
+XJog is published as 15 independently-versioned packages under the `@samihult/*`
+scope, to Telia's **JFrog Artifactory** npm repository (`ecom-npm-local`), driven
+by [Changesets](https://github.com/changesets/changesets).
+
+Publishing goes to JFrog from **any branch** — the registry is pinned two ways:
+
+- **`publishConfig.registry`** in every package's `package.json` — the publish
+  target.
+- **`@samihult:registry`** in the repo `.npmrc` — so Changesets' "is this version
+  already published?" check queries JFrog too (without it, the check hits npmjs,
+  wrongly concludes the version is new, and then fails on a duplicate).
+
+There is no special publish branch — that setup was removed in favour of the two
+config points above.
+
+## Prerequisites: authentication
+
+The `.npmrc` points the scope at JFrog but carries **no credentials**. Put a token
+in your **`~/.npmrc`** (user-level, never commit it):
+
+```
+//jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-local/:_authToken=<your-token>
+```
+
+Get the exact line from JFrog Artifactory → **Set Me Up** → npm. Verify:
+
+```bash
+npm whoami --registry=https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-local/
+```
+
+## Release steps (maintainers)
+
+A change is only released once its version is **bumped past what's on the
+registry** — that takes two distinct Changesets stages, `version` then `publish`.
+Skipping the `version` stage is the most common mistake (see
+[Troubleshooting](#troubleshooting)).
+
+```bash
+git checkout main                    # release from the default branch
+git pull
+
+# 1. Ensure a changeset describing the release exists (normally committed with
+#    the PRs). If not, add one:
+pnpm changeset                        # keep bumps `patch` during alpha
+
+# 2. VERSION — consume changesets: bump package.json versions + write CHANGELOGs.
+#    This is the step people skip. Without it, versions don't move and step 4
+#    finds nothing new to publish.
+pnpm version-packages                 # e.g. 0.1.0 -> 0.1.1 across affected packages
+pnpm install                         # refresh the lockfile after the bumps
+git commit -am "Version packages"
+
+# 3. (sanity) preview what would be published, without pushing:
+pnpm -r publish --dry-run --no-git-checks
+
+# 4. PUBLISH — build, then publish versions not yet on JFrog.
+pnpm release                          # = turbo run build && changeset publish
+
+# 5. push the git tags Changesets created (e.g. @samihult/xjog@0.1.1):
+git push origin --tags
+```
+
+## Good to know
+
+- **Idempotent.** `changeset publish` only pushes versions **not already** on the
+  registry. Re-running after a partial failure publishes just the missing ones.
+- **`access: restricted`** (in `publishConfig` and `.changeset/config.json`) →
+  published as private, correct for an internal Artifactory repo.
+- **Workspace deps** (`workspace:^`) are rewritten to real version ranges by pnpm
+  at publish time — no manual step.
+- **Alpha versioning:** keep bumps `patch` so versions stay `0.1.x`.
+
+## Troubleshooting
+
+**`warn ... is not being published because version X is already published` /
+`No unpublished projects to publish`** — the version in `package.json` already
+exists on JFrog. Almost always:
+
+1. **You skipped `pnpm version-packages`.** The changeset is still pending and
+   versions are unchanged, so `changeset publish` sees the current (already
+   published) version and skips. Run `version-packages`, commit, then `release`.
+2. **The version genuinely is already on JFrog** — nothing to do; cut a new
+   version to publish again (you can't overwrite an existing version).
+
+**Check where a version actually lives** (a scope override is required — a bare
+`--registry` is ignored for scoped packages because `@samihult:registry` in
+`.npmrc` wins):
+
+```bash
+# On JFrog?
+npm view @samihult/xjog@0.1.1 version \
+  --@samihult:registry=https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-local/
+
+# On public npmjs? (should always 404 — these are private)
+npm view @samihult/xjog@0.1.1 version \
+  --@samihult:registry=https://registry.npmjs.org
+```

--- a/packages/core-persistence/package.json
+++ b/packages/core-persistence/package.json
@@ -12,8 +12,8 @@
     "harel",
     "xjog"
   ],
-  "repository": "https://github.com/samihult/xjog",
-  "homepage": "https://www.xjog.io/",
+  "repository": "https://github.com/telia-oss/xjog",
+  "homepage": "https://github.com/telia-oss/xjog",
   "author": "Sami Hult <sami.hult@gmail.com>",
   "license": "MIT",
   "private": false,
@@ -35,5 +35,9 @@
     "@samihult/xjog-util": "workspace:^",
     "xstate": "4.38.3"
   },
-  "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
+  "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
+  "publishConfig": {
+    "registry": "https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-local/",
+    "access": "restricted"
+  }
 }

--- a/packages/core-pg/package.json
+++ b/packages/core-pg/package.json
@@ -12,8 +12,8 @@
 		"harel",
 		"xjog"
 	],
-	"repository": "https://github.com/samihult/xjog",
-	"homepage": "https://www.xjog.io/",
+	"repository": "https://github.com/telia-oss/xjog",
+	"homepage": "https://github.com/telia-oss/xjog",
 	"author": "Sami Hult <sami.hult@gmail.com>",
 	"license": "MIT",
 	"private": false,
@@ -44,5 +44,9 @@
 	"devDependencies": {
 		"@types/pg": "8.20.0"
 	},
-	"gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
+	"gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
+	"publishConfig": {
+		"registry": "https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-local/",
+		"access": "restricted"
+	}
 }

--- a/packages/core-pglite/package.json
+++ b/packages/core-pglite/package.json
@@ -7,7 +7,7 @@
   ],
   "author": "Juha Mustonen <juha.mustonen@iki.fi>",
   "private": false,
-  "homepage": "",
+  "homepage": "https://github.com/telia-oss/xjog",
   "license": "MIT",
   "main": "lib",
   "directories": {
@@ -34,6 +34,10 @@
     "node-pg-migrate": "^6.2.1",
     "xstate": "4.38.3"
   },
-  "devDependencies": {},
-  "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
+  "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
+  "publishConfig": {
+    "registry": "https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-local/",
+    "access": "restricted"
+  },
+  "repository": "https://github.com/telia-oss/xjog"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,8 +12,8 @@
 		"harel",
 		"xstate"
 	],
-	"repository": "https://github.com/samihult/xjog",
-	"homepage": "https://www.xjog.io/",
+	"repository": "https://github.com/telia-oss/xjog",
+	"homepage": "https://github.com/telia-oss/xjog",
 	"author": "Sami Hult <sami.hult@gmail.com>",
 	"license": "MIT",
 	"private": false,
@@ -45,5 +45,9 @@
 	"gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
 	"peerDependencies": {
 		"rxjs": "^7.8.2"
+	},
+	"publishConfig": {
+		"registry": "https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-local/",
+		"access": "restricted"
 	}
 }

--- a/packages/digest-persistence/package.json
+++ b/packages/digest-persistence/package.json
@@ -12,8 +12,8 @@
     "harel",
     "xjog"
   ],
-  "repository": "https://github.com/samihult/xjog",
-  "homepage": "https://www.xjog.io/",
+  "repository": "https://github.com/telia-oss/xjog",
+  "homepage": "https://github.com/telia-oss/xjog",
   "author": "Sami Hult <sami.hult@gmail.com>",
   "license": "MIT",
   "private": false,
@@ -32,9 +32,12 @@
   "dependencies": {
     "@samihult/xjog-util": "workspace:^"
   },
-  "devDependencies": {},
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
   "peerDependencies": {
     "rxjs": "^7.8.2"
+  },
+  "publishConfig": {
+    "registry": "https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-local/",
+    "access": "restricted"
   }
 }

--- a/packages/digest-pg/package.json
+++ b/packages/digest-pg/package.json
@@ -12,8 +12,8 @@
 		"harel",
 		"xjog"
 	],
-	"repository": "https://github.com/samihult/xjog",
-	"homepage": "https://www.xjog.io/",
+	"repository": "https://github.com/telia-oss/xjog",
+	"homepage": "https://github.com/telia-oss/xjog",
 	"author": "Sami Hult <sami.hult@gmail.com>",
 	"license": "MIT",
 	"private": false,
@@ -43,5 +43,9 @@
 	"devDependencies": {
 		"@types/pg": "8.20.0"
 	},
-	"gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
+	"gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
+	"publishConfig": {
+		"registry": "https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-local/",
+		"access": "restricted"
+	}
 }

--- a/packages/digest-pglite/package.json
+++ b/packages/digest-pglite/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Digest package with PGlite backend",
   "author": "Juha Mustonen <juha.mustonen@iki.fi>",
-  "homepage": "",
+  "homepage": "https://github.com/telia-oss/xjog",
   "license": "MIT",
   "main": "lib",
   "directories": {
@@ -28,5 +28,9 @@
     "@samihult/xjog-util": "workspace:^",
     "node-pg-migrate": "^6.2.1"
   },
-  "devDependencies": {}
+  "publishConfig": {
+    "registry": "https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-local/",
+    "access": "restricted"
+  },
+  "repository": "https://github.com/telia-oss/xjog"
 }

--- a/packages/digest-reader/package.json
+++ b/packages/digest-reader/package.json
@@ -12,8 +12,8 @@
     "harel",
     "xjog"
   ],
-  "repository": "https://github.com/samihult/xjog",
-  "homepage": "https://www.xjog.io/",
+  "repository": "https://github.com/telia-oss/xjog",
+  "homepage": "https://github.com/telia-oss/xjog",
   "author": "Sami Hult <sami.hult@gmail.com>",
   "license": "MIT",
   "private": false,
@@ -35,9 +35,12 @@
     "@samihult/xjog-digest-persistence": "workspace:^",
     "@samihult/xjog-util": "workspace:^"
   },
-  "devDependencies": {},
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
   "peerDependencies": {
     "rxjs": "^7.8.2"
+  },
+  "publishConfig": {
+    "registry": "https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-local/",
+    "access": "restricted"
   }
 }

--- a/packages/digest-writer/package.json
+++ b/packages/digest-writer/package.json
@@ -12,8 +12,8 @@
 		"harel",
 		"xjog"
 	],
-	"repository": "https://github.com/samihult/xjog",
-	"homepage": "https://www.xjog.io/",
+	"repository": "https://github.com/telia-oss/xjog",
+	"homepage": "https://github.com/telia-oss/xjog",
 	"author": "Sami Hult <sami.hult@gmail.com>",
 	"license": "MIT",
 	"private": false,
@@ -42,5 +42,9 @@
 	"devDependencies": {
 		"@types/pg": "8.20.0"
 	},
-	"gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
+	"gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
+	"publishConfig": {
+		"registry": "https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-local/",
+		"access": "restricted"
+	}
 }

--- a/packages/journal-persistence/package.json
+++ b/packages/journal-persistence/package.json
@@ -12,8 +12,8 @@
     "harel",
     "xjog"
   ],
-  "repository": "https://github.com/samihult/xjog",
-  "homepage": "https://www.xjog.io/",
+  "repository": "https://github.com/telia-oss/xjog",
+  "homepage": "https://github.com/telia-oss/xjog",
   "author": "Sami Hult <sami.hult@gmail.com>",
   "license": "MIT",
   "private": false,
@@ -39,5 +39,9 @@
   "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
   "peerDependencies": {
     "rxjs": "^7.8.2"
+  },
+  "publishConfig": {
+    "registry": "https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-local/",
+    "access": "restricted"
   }
 }

--- a/packages/journal-pg/package.json
+++ b/packages/journal-pg/package.json
@@ -12,8 +12,8 @@
 		"harel",
 		"xjog"
 	],
-	"repository": "https://github.com/samihult/xjog",
-	"homepage": "https://www.xjog.io/",
+	"repository": "https://github.com/telia-oss/xjog",
+	"homepage": "https://github.com/telia-oss/xjog",
 	"author": "Sami Hult <sami.hult@gmail.com>",
 	"license": "MIT",
 	"private": false,
@@ -44,5 +44,9 @@
 	"devDependencies": {
 		"@types/pg": "8.20.0"
 	},
-	"gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
+	"gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
+	"publishConfig": {
+		"registry": "https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-local/",
+		"access": "restricted"
+	}
 }

--- a/packages/journal-pglite/package.json
+++ b/packages/journal-pglite/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "> TODO: description",
   "author": "Juha Mustonen <juha.mustonen@iki.fi>",
-  "homepage": "",
+  "homepage": "https://github.com/telia-oss/xjog",
   "license": "MIT",
   "main": "lib",
   "directories": {
@@ -29,5 +29,9 @@
     "node-pg-migrate": "^6.2.1",
     "xstate": "4.38.3"
   },
-  "devDependencies": {}
+  "publishConfig": {
+    "registry": "https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-local/",
+    "access": "restricted"
+  },
+  "repository": "https://github.com/telia-oss/xjog"
 }

--- a/packages/journal-reader/package.json
+++ b/packages/journal-reader/package.json
@@ -12,8 +12,8 @@
 		"harel",
 		"xjog"
 	],
-	"repository": "https://github.com/samihult/xjog",
-	"homepage": "https://www.xjog.io/",
+	"repository": "https://github.com/telia-oss/xjog",
+	"homepage": "https://github.com/telia-oss/xjog",
 	"author": "Sami Hult <sami.hult@gmail.com>",
 	"license": "MIT",
 	"private": false,
@@ -47,5 +47,9 @@
 	"gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
 	"peerDependencies": {
 		"rxjs": "^7.8.2"
+	},
+	"publishConfig": {
+		"registry": "https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-local/",
+		"access": "restricted"
 	}
 }

--- a/packages/journal-writer/package.json
+++ b/packages/journal-writer/package.json
@@ -12,8 +12,8 @@
     "harel",
     "xjog"
   ],
-  "repository": "https://github.com/samihult/xjog",
-  "homepage": "https://www.xjog.io/",
+  "repository": "https://github.com/telia-oss/xjog",
+  "homepage": "https://github.com/telia-oss/xjog",
   "author": "Sami Hult <sami.hult@gmail.com>",
   "license": "MIT",
   "private": false,
@@ -34,6 +34,9 @@
     "@samihult/xjog-journal-persistence": "workspace:^",
     "@samihult/xjog-util": "workspace:^"
   },
-  "devDependencies": {},
-  "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
+  "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
+  "publishConfig": {
+    "registry": "https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-local/",
+    "access": "restricted"
+  }
 }

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -12,8 +12,8 @@
     "harel",
     "xjog"
   ],
-  "repository": "https://github.com/samihult/xjog",
-  "homepage": "https://www.xjog.io/",
+  "repository": "https://github.com/telia-oss/xjog",
+  "homepage": "https://github.com/telia-oss/xjog",
   "author": "Sami Hult <sami.hult@gmail.com>",
   "license": "MIT",
   "private": false,
@@ -33,6 +33,9 @@
     "rfc6902": "^5.0.1",
     "xstate": "4.38.3"
   },
-  "devDependencies": {},
-  "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb"
+  "gitHead": "296d7424a400009e863c25c455dd4b5d26139dcb",
+  "publishConfig": {
+    "registry": "https://jfrog.teliacompany.io/artifactory/api/npm/ecom-npm-local/",
+    "access": "restricted"
+  }
 }


### PR DESCRIPTION
## What

Make publishing to JFrog robust and branch-independent, and retire the `publish`
branch. Part of the hard-fork cleanup (Phase 2 + metadata).

## Changes

- **`publishConfig`** on all 15 packages → `registry` = JFrog `ecom-npm-local`,
  `access: restricted`. Publishing now targets JFrog **from any branch**.
- **`.npmrc`**: repoint `@samihult:registry` from GitHub Packages → JFrog (the old
  value was a dead fossil from the original project). This makes `changeset
  publish`'s "already published?" check hit JFrog too, so it can't wrongly try to
  republish an existing version.
- **Retired the `publish` branch.** Its only purpose was a branch-specific
  `.npmrc`; that's now covered by `publishConfig` + the fixed `.npmrc`, in one
  place, on every branch. Removes the "released from the wrong branch → wrong
  registry" class of bug.
- **Metadata**: `repository`/`homepage` → `telia-oss/xjog` on all packages
  (were pointing at `samihult/xjog` / `xjog.io`; 3 pglite packages had none).
  Original `author` credits kept.
- **Docs**: rewrote `contributing/releasing.md` for the new flow (no publish
  branch; two-stage `version` → `publish`; troubleshooting the "already
  published / nothing to publish" trap) and updated `development.md`.

## Release impact

The pending changeset bumps all 15 by `patch`. No runtime code changes — this is
packaging/config only.

## Not in this PR

The `@samihult` → `@telia-oss` scope rename (Phase 3) is separate — it's a
coordinated, breaking change since internal apps depend on `@samihult/*`.

## Verification

- `pnpm run lint` clean, `pnpm run build` green.
- Root `package.json` untouched (private); per-file indentation and author fields
  preserved.
