### PR TITLE
Deduplicate digest filterQuery into shared package (TODO A1)

### DIFF
--- a/.changeset/digest-shared-filterquery.md
+++ b/.changeset/digest-shared-filterquery.md
@@ -1,0 +1,7 @@
+---
+'@telia-oss/xjog-digest-persistence': patch
+'@telia-oss/xjog-digest-pg': patch
+'@telia-oss/xjog-digest-pglite': patch
+---
+
+Deduplicate the digest `filterQuery` builder into the shared digest-persistence package.

--- a/packages/digest-persistence/jest.config.js
+++ b/packages/digest-persistence/jest.config.js
@@ -1,0 +1,6 @@
+const baseConfig = require('../jestconfig.base');
+
+module.exports = {
+  ...baseConfig,
+  rootDir: 'src',
+};

--- a/packages/digest-persistence/package.json
+++ b/packages/digest-persistence/package.json
@@ -27,7 +27,8 @@
     "clean": "rm -rf node_modules lib",
     "lint": "pnpm exec biome ci .",
     "lint:fix": "pnpm exec biome check --write .",
-    "format": "pnpm exec biome format --write ."
+    "format": "pnpm exec biome format --write .",
+    "test": "pnpm exec jest --passWithNoTests"
   },
   "dependencies": {
     "@telia-oss/xjog-util": "workspace:^"

--- a/packages/digest-persistence/src/filterQuery.test.ts
+++ b/packages/digest-persistence/src/filterQuery.test.ts
@@ -1,0 +1,167 @@
+import type { Expression } from './DigestQuery';
+import { filterQuery } from './filterQuery';
+
+describe('filterQuery', () => {
+  it('returns an empty query and no bindings when no expression is given', () => {
+    const [sql, bindings] = filterQuery(undefined);
+
+    expect(sql).toBe('');
+    expect(bindings).toEqual({});
+  });
+
+  it('builds an "eq" condition', () => {
+    const expression: Expression = { op: 'eq', left: 'name', right: 'Bob' };
+    const [sql, bindings] = filterQuery(expression);
+
+    expect(sql).toContain('"candidate"."key" = :key_q_eq');
+    expect(sql).toContain('"candidate"."value" = :value_q_eq');
+    expect(bindings).toEqual({
+      key_q_eq: 'name',
+      value_q_eq: 'Bob',
+    });
+  });
+
+  it('builds a "matches" condition', () => {
+    const expression: Expression = {
+      op: 'matches',
+      left: 'birthday',
+      right: '1982-\\d{2}-\\d{2}',
+    };
+    const [sql, bindings] = filterQuery(expression);
+
+    expect(sql).toContain('"candidate"."key" = :key_q_re');
+    expect(sql).toContain('"candidate"."value" ~ :value_q_re');
+    expect(bindings).toEqual({
+      key_q_re: 'birthday',
+      value_q_re: '1982-\\d{2}-\\d{2}',
+    });
+  });
+
+  it.each([
+    ['<', 'lt', '<'],
+    ['>', 'gt', '>'],
+    ['<=', 'lte', '<='],
+    ['>=', 'gte', '>='],
+  ] as const)('builds a "%s" numeric comparison condition', (op, opAbbrev, sqlOperator) => {
+    const expression: Expression = {
+      op,
+      left: 'itemQuantity',
+      right: 99,
+    };
+    const [sql, bindings] = filterQuery(expression);
+
+    expect(sql).toContain(`"candidate"."key" = :key_q_${opAbbrev}`);
+    expect(sql).toContain(
+      `"candidate"."value"::decimal ${sqlOperator} :value_q_${opAbbrev}::decimal`,
+    );
+    expect(bindings).toEqual({
+      [`key_q_${opAbbrev}`]: 'itemQuantity',
+      [`value_q_${opAbbrev}`]: 99,
+    });
+  });
+
+  it.each([
+    ['created before', 'crbef', '>'],
+    ['updated before', 'udbef', '>'],
+    ['created after', 'craft', '<'],
+    ['updated after', 'udaft', '<'],
+  ] as const)('builds a "%s" timestamp condition', (op, opAbbrev, comparison) => {
+    const dateTime = new Date('2024-01-01T00:00:00.000Z');
+    const expression: Expression = { op, dateTime };
+    const [sql, bindings] = filterQuery(expression);
+
+    expect(sql.startsWith('NOT ')).toBe(true);
+    expect(sql).toContain(`to_timestamp(:value_q_${opAbbrev}::decimal / 1000)`);
+    expect(sql).toContain(`${comparison} to_timestamp`);
+    expect(bindings).toEqual({
+      [`value_q_${opAbbrev}`]: dateTime.valueOf(),
+    });
+  });
+
+  it('builds a "not" condition wrapping the operand', () => {
+    const expression: Expression = {
+      op: 'not',
+      operand: { op: 'eq', left: 'name', right: 'Bob' },
+    };
+    const [sql, bindings] = filterQuery(expression);
+
+    expect(sql.startsWith('NOT (')).toBe(true);
+    expect(bindings).toEqual({
+      key_q_not_eq: 'name',
+      value_q_not_eq: 'Bob',
+    });
+  });
+
+  it('builds an "and" condition combining left and right with unique bindings', () => {
+    const expression: Expression = {
+      op: 'and',
+      left: { op: 'eq', left: 'name', right: 'Bob' },
+      right: { op: '<=', left: 'itemQuantity', right: 99 },
+    };
+    const [sql, bindings] = filterQuery(expression);
+
+    expect(sql).toContain(' AND ');
+    expect(bindings).toEqual({
+      key_q_and_lt_eq: 'name',
+      value_q_and_lt_eq: 'Bob',
+      key_q_and_rt_lte: 'itemQuantity',
+      value_q_and_rt_lte: 99,
+    });
+  });
+
+  it('builds an "or" condition combining left and right with unique bindings', () => {
+    const expression: Expression = {
+      op: 'or',
+      left: { op: 'eq', left: 'name', right: 'Bob' },
+      right: { op: 'eq', left: 'name', right: 'Alice' },
+    };
+    const [sql, bindings] = filterQuery(expression);
+
+    expect(sql).toContain(' OR ');
+    expect(bindings).toEqual({
+      key_q_or_lt_eq: 'name',
+      value_q_or_lt_eq: 'Bob',
+      key_q_or_rt_eq: 'name',
+      value_q_or_rt_eq: 'Alice',
+    });
+  });
+
+  it('keeps binding keys unique across deeply nested combinators', () => {
+    const expression: Expression = {
+      op: 'and',
+      left: {
+        op: 'or',
+        left: { op: 'eq', left: 'name', right: 'Bob' },
+        right: { op: 'eq', left: 'name', right: 'Alice' },
+      },
+      right: {
+        op: 'not',
+        operand: { op: '<', left: 'itemQuantity', right: 1 },
+      },
+    };
+    const [, bindings] = filterQuery(expression);
+    const keys = Object.keys(bindings);
+
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(bindings).toEqual({
+      key_q_and_lt_or_lt_eq: 'name',
+      value_q_and_lt_or_lt_eq: 'Bob',
+      key_q_and_lt_or_rt_eq: 'name',
+      value_q_and_lt_or_rt_eq: 'Alice',
+      key_q_and_rt_not_lt: 'itemQuantity',
+      value_q_and_rt_not_lt: 1,
+    });
+  });
+
+  it('respects a custom prefix', () => {
+    const expression: Expression = { op: 'eq', left: 'name', right: 'Bob' };
+    const [sql, bindings] = filterQuery(expression, 'custom');
+
+    expect(sql).toContain(':key_custom_eq');
+    expect(sql).toContain(':value_custom_eq');
+    expect(bindings).toEqual({
+      key_custom_eq: 'name',
+      value_custom_eq: 'Bob',
+    });
+  });
+});

--- a/packages/digest-persistence/src/filterQuery.ts
+++ b/packages/digest-persistence/src/filterQuery.ts
@@ -1,0 +1,202 @@
+import type { Expression } from './DigestQuery';
+
+/**
+ * Build a parameterized SQL fragment (and its bindings) matching a digest
+ * filter `Expression`. Shared by the pg and pglite digest persistence
+ * adapters so the filter-building logic only lives in one place.
+ *
+ * The recursion `prefix` already uniquely identifies this node, so the
+ * binding name needs only the operator to stay unique. The digest key is
+ * carried as a bound *value* (see addBindings), never interpolated into the
+ * name — embedding it here produced names with hyphens/dots/digits that
+ * downstream `:name` substitution (pg-bind, or the `:name` -> `$n` rewrite
+ * used by pglite) truncates, mis-binding the query.
+ */
+export function filterQuery(
+  expression?: Expression,
+  prefix = 'q',
+): [string, { [key: string]: string | number }] {
+  if (!expression) {
+    return ['', {}];
+  }
+
+  let queryString = '';
+  const bindings: Record<string, string | number> = {};
+
+  const createBindingKey = (op: 'eq' | 're' | 'lt' | 'lte' | 'gt' | 'gte') =>
+    `${prefix}_${op}`;
+
+  const keyMatchSql = (key: string, bindingKey: string): string =>
+    key ? `AND "candidate"."key" = :key_${bindingKey} ` : '';
+
+  const addBindings = (
+    bindingKey: string,
+    key: string,
+    pattern: string | number,
+  ) => {
+    bindings[`key_${bindingKey}`] = key;
+    bindings[`value_${bindingKey}`] = pattern;
+  };
+
+  const matchingSql = (conditionSql: string) =>
+    'EXISTS ' +
+    '(SELECT 1 FROM "digests" AS "candidate" ' +
+    'WHERE "candidate"."machineId" = "digests"."machineId" ' +
+    'AND "candidate"."chartId" = "digests"."chartId" ' +
+    conditionSql +
+    ')';
+
+  switch (expression.op) {
+    case 'eq': {
+      const bindingKey = createBindingKey('eq');
+      addBindings(bindingKey, expression.left, expression.right);
+      queryString += matchingSql(
+        keyMatchSql(expression.left, bindingKey) +
+          `AND "candidate"."value" = :value_${bindingKey} `,
+      );
+      break;
+    }
+
+    case 'matches': {
+      const bindingKey = createBindingKey('re');
+      addBindings(bindingKey, expression.left, expression.right);
+      queryString += matchingSql(
+        keyMatchSql(expression.left, bindingKey) +
+          `AND "candidate"."value" ~ :value_${bindingKey} `,
+      );
+      break;
+    }
+
+    // Numeric inequality
+
+    case '<': {
+      const bindingKey = createBindingKey('lt');
+      addBindings(bindingKey, expression.left, expression.right);
+      queryString += matchingSql(
+        keyMatchSql(expression.left, bindingKey) +
+          `AND "candidate"."value"::decimal < :value_${bindingKey}::decimal `,
+      );
+      break;
+    }
+
+    case '>': {
+      const bindingKey = createBindingKey('gt');
+      addBindings(bindingKey, expression.left, expression.right);
+      queryString += matchingSql(
+        keyMatchSql(expression.left, bindingKey) +
+          `AND "candidate"."value"::decimal > :value_${bindingKey}::decimal `,
+      );
+      break;
+    }
+
+    case '<=': {
+      const bindingKey = createBindingKey('lte');
+      addBindings(bindingKey, expression.left, expression.right);
+      queryString += matchingSql(
+        keyMatchSql(expression.left, bindingKey) +
+          `AND "candidate"."value"::decimal <= :value_${bindingKey}::decimal `,
+      );
+      break;
+    }
+
+    case '>=': {
+      const bindingKey = createBindingKey('gte');
+      addBindings(bindingKey, expression.left, expression.right);
+      queryString += matchingSql(
+        keyMatchSql(expression.left, bindingKey) +
+          `AND "candidate"."value"::decimal >= :value_${bindingKey}::decimal `,
+      );
+      break;
+    }
+
+    // Timestamps
+
+    case 'created before': {
+      const bindingKey = `${prefix}_crbef`;
+      bindings[`value_${bindingKey}`] = expression.dateTime.valueOf();
+      queryString +=
+        'NOT ' +
+        matchingSql(
+          `AND "candidate"."created" > to_timestamp(:value_${bindingKey}::decimal / 1000) `,
+        );
+      break;
+    }
+
+    case 'updated before': {
+      const bindingKey = `${prefix}_udbef`;
+      bindings[`value_${bindingKey}`] = expression.dateTime.valueOf();
+      queryString +=
+        'NOT ' +
+        matchingSql(
+          `AND "candidate"."timestamp" > to_timestamp(:value_${bindingKey}::decimal / 1000) `,
+        );
+      break;
+    }
+
+    case 'created after': {
+      const bindingKey = `${prefix}_craft`;
+      bindings[`value_${bindingKey}`] = expression.dateTime.valueOf();
+      queryString +=
+        'NOT ' +
+        matchingSql(
+          `AND "candidate"."created" < to_timestamp(:value_${bindingKey}::decimal / 1000) `,
+        );
+      break;
+    }
+
+    case 'updated after': {
+      const bindingKey = `${prefix}_udaft`;
+      bindings[`value_${bindingKey}`] = expression.dateTime.valueOf();
+      queryString +=
+        'NOT ' +
+        matchingSql(
+          `AND "candidate"."timestamp" < to_timestamp(:value_${bindingKey}::decimal / 1000) `,
+        );
+      break;
+    }
+
+    // Combinators
+
+    case 'not': {
+      const [subQueryString, subQueryBindings] = filterQuery(
+        expression.operand,
+        `${prefix}_not`,
+      );
+      queryString += `NOT (${subQueryString}) `;
+      Object.assign(bindings, subQueryBindings);
+      break;
+    }
+
+    case 'and': {
+      const [leftQueryString, leftQueryBindings] = filterQuery(
+        expression.left,
+        `${prefix}_and_lt`,
+      );
+      const [rightQueryString, rightQueryBindings] = filterQuery(
+        expression.right,
+        `${prefix}_and_rt`,
+      );
+      queryString += `${leftQueryString} AND ${rightQueryString} `;
+      Object.assign(bindings, leftQueryBindings);
+      Object.assign(bindings, rightQueryBindings);
+      break;
+    }
+
+    case 'or': {
+      const [leftQueryString, leftQueryBindings] = filterQuery(
+        expression.left,
+        `${prefix}_or_lt`,
+      );
+      const [rightQueryString, rightQueryBindings] = filterQuery(
+        expression.right,
+        `${prefix}_or_rt`,
+      );
+      queryString += `${leftQueryString} OR ${rightQueryString} `;
+      Object.assign(bindings, leftQueryBindings);
+      Object.assign(bindings, rightQueryBindings);
+      break;
+    }
+  }
+
+  return [`${queryString}`, bindings];
+}

--- a/packages/digest-persistence/src/index.ts
+++ b/packages/digest-persistence/src/index.ts
@@ -2,3 +2,4 @@ export * from './DigestEntries';
 export * from './DigestEntry';
 export * from './DigestPersistenceAdapter';
 export * from './DigestQuery';
+export * from './filterQuery';

--- a/packages/digest-pg/src/PostgresDigestPersistenceAdapter.ts
+++ b/packages/digest-pg/src/PostgresDigestPersistenceAdapter.ts
@@ -5,7 +5,7 @@ import {
   type DigestEntry,
   DigestPersistenceAdapter,
   type DigestQuery,
-  type Expression,
+  filterQuery,
 } from '@telia-oss/xjog-digest-persistence';
 import type { ChartReference } from '@telia-oss/xjog-util';
 import migrationRunner from 'node-pg-migrate';
@@ -210,8 +210,7 @@ export class PostgresDigestPersistenceAdapter extends DigestPersistenceAdapter {
   public async queryDigests(
     digestQuery?: DigestQuery,
   ): Promise<ChartReferenceWithTimestamp[]> {
-    const [filterQuery, filterBindings] =
-      PostgresDigestPersistenceAdapter.filterQuery(digestQuery?.query);
+    const [filterQueryString, filterBindings] = filterQuery(digestQuery?.query);
 
     const boundSql = bind(
       'SELECT DISTINCT "machineId", "chartId", ' +
@@ -223,7 +222,7 @@ export class PostgresDigestPersistenceAdapter extends DigestPersistenceAdapter {
         (digestQuery?.chartId !== undefined
           ? '  AND "chartId" = :chartId '
           : '') +
-        (filterQuery ? `AND (${filterQuery}) ` : '') +
+        (filterQueryString ? `AND (${filterQueryString}) ` : '') +
         'GROUP BY "machineId", "chartId" ' +
         'ORDER BY "timestamp" ' +
         (digestQuery?.order ?? 'ASC') +
@@ -241,205 +240,6 @@ export class PostgresDigestPersistenceAdapter extends DigestPersistenceAdapter {
     const result = await this.pool.query<ChartReferenceWithTimestamp>(boundSql);
 
     return result.rows;
-  }
-
-  static filterQuery(
-    expression?: Expression,
-    prefix = 'q',
-  ): [string, { [key: string]: string | number }] {
-    if (!expression) {
-      return ['', {}];
-    }
-
-    let queryString = '';
-    const bindings: Record<string, string | number> = {};
-
-    // The recursion `prefix` already uniquely identifies this node, so the
-    // binding name needs only the operator to stay unique. The digest key is
-    // carried as a bound *value* (see addBindings), never interpolated into the
-    // name — embedding it here produced names with hyphens/dots/digits that
-    // pg-bind's `:name` matcher (`[a-zA-Z_]+`) truncates, mis-binding the query.
-    const createBindingKey = (op: 'eq' | 're' | 'lt' | 'lte' | 'gt' | 'gte') =>
-      `${prefix}_${op}`;
-
-    const keyMatchSql = (key: string, bindingKey: string): string =>
-      key ? `AND "candidate"."key" = :key_${bindingKey} ` : '';
-
-    const addBindings = (
-      bindingKey: string,
-      key: string,
-      pattern: string | number,
-    ) => {
-      bindings[`key_${bindingKey}`] = key;
-      bindings[`value_${bindingKey}`] = pattern;
-    };
-
-    const matchingSql = (conditionSql: string) =>
-      'EXISTS ' +
-      '(SELECT 1 FROM "digests" AS "candidate" ' +
-      'WHERE "candidate"."machineId" = "digests"."machineId" ' +
-      'AND "candidate"."chartId" = "digests"."chartId" ' +
-      conditionSql +
-      ')';
-
-    switch (expression.op) {
-      case 'eq': {
-        const bindingKey = createBindingKey('eq');
-        addBindings(bindingKey, expression.left, expression.right);
-        queryString += matchingSql(
-          keyMatchSql(expression.left, bindingKey) +
-            `AND "candidate"."value" = :value_${bindingKey} `,
-        );
-        break;
-      }
-
-      case 'matches': {
-        const bindingKey = createBindingKey('re');
-        addBindings(bindingKey, expression.left, expression.right);
-        queryString += matchingSql(
-          keyMatchSql(expression.left, bindingKey) +
-            `AND "candidate"."value" ~ :value_${bindingKey} `,
-        );
-        break;
-      }
-
-      // Numeric inequality
-
-      case '<': {
-        const bindingKey = createBindingKey('lt');
-        addBindings(bindingKey, expression.left, expression.right);
-        queryString += matchingSql(
-          keyMatchSql(expression.left, bindingKey) +
-            `AND "candidate"."value"::decimal < :value_${bindingKey}::decimal `,
-        );
-        break;
-      }
-
-      case '>': {
-        const bindingKey = createBindingKey('gt');
-        addBindings(bindingKey, expression.left, expression.right);
-        queryString += matchingSql(
-          keyMatchSql(expression.left, bindingKey) +
-            `AND "candidate"."value"::decimal > :value_${bindingKey}::decimal `,
-        );
-        break;
-      }
-
-      case '<=': {
-        const bindingKey = createBindingKey('lte');
-        addBindings(bindingKey, expression.left, expression.right);
-        queryString += matchingSql(
-          keyMatchSql(expression.left, bindingKey) +
-            `AND "candidate"."value"::decimal <= :value_${bindingKey}::decimal `,
-        );
-        break;
-      }
-
-      case '>=': {
-        const bindingKey = createBindingKey('gte');
-        addBindings(bindingKey, expression.left, expression.right);
-        queryString += matchingSql(
-          keyMatchSql(expression.left, bindingKey) +
-            `AND "candidate"."value"::decimal >= :value_${bindingKey}::decimal `,
-        );
-        break;
-      }
-
-      // Timestamps
-
-      case 'created before': {
-        const bindingKey = `${prefix}_crbef`;
-        bindings[`value_${bindingKey}`] = expression.dateTime.valueOf();
-        queryString +=
-          'NOT ' +
-          matchingSql(
-            `AND "candidate"."created" > to_timestamp(:value_${bindingKey}::decimal / 1000) `,
-          );
-        break;
-      }
-
-      case 'updated before': {
-        const bindingKey = `${prefix}_udbef`;
-        bindings[`value_${bindingKey}`] = expression.dateTime.valueOf();
-        queryString +=
-          'NOT ' +
-          matchingSql(
-            `AND "candidate"."timestamp" > to_timestamp(:value_${bindingKey}::decimal / 1000) `,
-          );
-        break;
-      }
-
-      case 'created after': {
-        const bindingKey = `${prefix}_craft`;
-        bindings[`value_${bindingKey}`] = expression.dateTime.valueOf();
-        queryString +=
-          'NOT ' +
-          matchingSql(
-            `AND "candidate"."created" < to_timestamp(:value_${bindingKey}::decimal / 1000) `,
-          );
-        break;
-      }
-
-      case 'updated after': {
-        const bindingKey = `${prefix}_udaft`;
-        bindings[`value_${bindingKey}`] = expression.dateTime.valueOf();
-        queryString +=
-          'NOT ' +
-          matchingSql(
-            `AND "candidate"."timestamp" < to_timestamp(:value_${bindingKey}::decimal / 1000) `,
-          );
-        break;
-      }
-
-      // Combinators
-
-      case 'not': {
-        const [subQueryString, subQueryBindings] =
-          PostgresDigestPersistenceAdapter.filterQuery(
-            expression.operand,
-            `${prefix}_not`,
-          );
-        queryString += `NOT (${subQueryString}) `;
-        Object.assign(bindings, subQueryBindings);
-        break;
-      }
-
-      case 'and': {
-        const [leftQueryString, leftQueryBindings] =
-          PostgresDigestPersistenceAdapter.filterQuery(
-            expression.left,
-            `${prefix}_and_lt`,
-          );
-        const [rightQueryString, rightQueryBindings] =
-          PostgresDigestPersistenceAdapter.filterQuery(
-            expression.right,
-            `${prefix}_and_rt`,
-          );
-        queryString += `${leftQueryString} AND ${rightQueryString} `;
-        Object.assign(bindings, leftQueryBindings);
-        Object.assign(bindings, rightQueryBindings);
-        break;
-      }
-
-      case 'or': {
-        const [leftQueryString, leftQueryBindings] =
-          PostgresDigestPersistenceAdapter.filterQuery(
-            expression.left,
-            `${prefix}_or_lt`,
-          );
-        const [rightQueryString, rightQueryBindings] =
-          PostgresDigestPersistenceAdapter.filterQuery(
-            expression.right,
-            `${prefix}_or_rt`,
-          );
-        queryString += `${leftQueryString} OR ${rightQueryString} `;
-        Object.assign(bindings, leftQueryBindings);
-        Object.assign(bindings, rightQueryBindings);
-        break;
-      }
-    }
-
-    return [`${queryString}`, bindings];
   }
 
   private async startObservingNewDigestEntries(): Promise<() => Promise<void>> {

--- a/packages/digest-pglite/src/PGliteDigestPersistenceAdapter.ts
+++ b/packages/digest-pglite/src/PGliteDigestPersistenceAdapter.ts
@@ -6,7 +6,7 @@ import {
   type DigestEntry,
   DigestPersistenceAdapter,
   type DigestQuery,
-  type Expression,
+  filterQuery,
 } from '@telia-oss/xjog-digest-persistence';
 import {
   type ChartReference,
@@ -167,8 +167,7 @@ export class PGliteDigestPersistenceAdapter extends DigestPersistenceAdapter {
   public async queryDigests(
     digestQuery?: DigestQuery,
   ): Promise<ChartReferenceWithTimestamp[]> {
-    const [filterQuery, filterBindings] =
-      PGliteDigestPersistenceAdapter.filterQuery(digestQuery?.query);
+    const [filterQueryString, filterBindings] = filterQuery(digestQuery?.query);
 
     // PGlite takes positional parameters only, so placeholders are numbered
     // in the order their conditions are appended, and the named `:binding`
@@ -188,9 +187,9 @@ export class PGliteDigestPersistenceAdapter extends DigestPersistenceAdapter {
       sql += `  AND "chartId" = ${nextParam(digestQuery.chartId)} `;
     }
 
-    if (filterQuery) {
+    if (filterQueryString) {
       // Match `:name` but not the `::type` casts also present in the SQL
-      const positionalFilterQuery = filterQuery.replace(
+      const positionalFilterQuery = filterQueryString.replace(
         /(^|[^:]):([A-Za-z0-9_]+)/g,
         (_match, precedingChar, bindingName) =>
           `${precedingChar}${nextParam(filterBindings[bindingName])}`,
@@ -217,205 +216,6 @@ export class PGliteDigestPersistenceAdapter extends DigestPersistenceAdapter {
     );
 
     return result.rows;
-  }
-
-  static filterQuery(
-    expression?: Expression,
-    prefix = 'q',
-  ): [string, { [key: string]: string | number }] {
-    if (!expression) {
-      return ['', {}];
-    }
-
-    let queryString = '';
-    const bindings: Record<string, string | number> = {};
-
-    // The recursion `prefix` already uniquely identifies this node, so the
-    // binding name needs only the operator to stay unique. The digest key is
-    // carried as a bound *value* (see addBindings), never interpolated into the
-    // name — embedding it here produced names with hyphens/dots/digits that the
-    // `:name` -> `$n` substitution truncates, mis-binding the query.
-    const createBindingKey = (op: 'eq' | 're' | 'lt' | 'lte' | 'gt' | 'gte') =>
-      `${prefix}_${op}`;
-
-    const keyMatchSql = (key: string, bindingKey: string): string =>
-      key ? `AND "candidate"."key" = :key_${bindingKey} ` : '';
-
-    const addBindings = (
-      bindingKey: string,
-      key: string,
-      pattern: string | number,
-    ) => {
-      bindings[`key_${bindingKey}`] = key;
-      bindings[`value_${bindingKey}`] = pattern;
-    };
-
-    const matchingSql = (conditionSql: string) =>
-      'EXISTS ' +
-      '(SELECT 1 FROM "digests" AS "candidate" ' +
-      'WHERE "candidate"."machineId" = "digests"."machineId" ' +
-      'AND "candidate"."chartId" = "digests"."chartId" ' +
-      conditionSql +
-      ')';
-
-    switch (expression.op) {
-      case 'eq': {
-        const bindingKey = createBindingKey('eq');
-        addBindings(bindingKey, expression.left, expression.right);
-        queryString += matchingSql(
-          keyMatchSql(expression.left, bindingKey) +
-            `AND "candidate"."value" = :value_${bindingKey} `,
-        );
-        break;
-      }
-
-      case 'matches': {
-        const bindingKey = createBindingKey('re');
-        addBindings(bindingKey, expression.left, expression.right);
-        queryString += matchingSql(
-          keyMatchSql(expression.left, bindingKey) +
-            `AND "candidate"."value" ~ :value_${bindingKey} `,
-        );
-        break;
-      }
-
-      // Numeric inequality
-
-      case '<': {
-        const bindingKey = createBindingKey('lt');
-        addBindings(bindingKey, expression.left, expression.right);
-        queryString += matchingSql(
-          keyMatchSql(expression.left, bindingKey) +
-            `AND "candidate"."value"::decimal < :value_${bindingKey}::decimal `,
-        );
-        break;
-      }
-
-      case '>': {
-        const bindingKey = createBindingKey('gt');
-        addBindings(bindingKey, expression.left, expression.right);
-        queryString += matchingSql(
-          keyMatchSql(expression.left, bindingKey) +
-            `AND "candidate"."value"::decimal > :value_${bindingKey}::decimal `,
-        );
-        break;
-      }
-
-      case '<=': {
-        const bindingKey = createBindingKey('lte');
-        addBindings(bindingKey, expression.left, expression.right);
-        queryString += matchingSql(
-          keyMatchSql(expression.left, bindingKey) +
-            `AND "candidate"."value"::decimal <= :value_${bindingKey}::decimal `,
-        );
-        break;
-      }
-
-      case '>=': {
-        const bindingKey = createBindingKey('gte');
-        addBindings(bindingKey, expression.left, expression.right);
-        queryString += matchingSql(
-          keyMatchSql(expression.left, bindingKey) +
-            `AND "candidate"."value"::decimal >= :value_${bindingKey}::decimal `,
-        );
-        break;
-      }
-
-      // Timestamps
-
-      case 'created before': {
-        const bindingKey = `${prefix}_crbef`;
-        bindings[`value_${bindingKey}`] = expression.dateTime.valueOf();
-        queryString +=
-          'NOT ' +
-          matchingSql(
-            `AND "candidate"."created" > to_timestamp(:value_${bindingKey}::decimal / 1000) `,
-          );
-        break;
-      }
-
-      case 'updated before': {
-        const bindingKey = `${prefix}_udbef`;
-        bindings[`value_${bindingKey}`] = expression.dateTime.valueOf();
-        queryString +=
-          'NOT ' +
-          matchingSql(
-            `AND "candidate"."timestamp" > to_timestamp(:value_${bindingKey}::decimal / 1000) `,
-          );
-        break;
-      }
-
-      case 'created after': {
-        const bindingKey = `${prefix}_craft`;
-        bindings[`value_${bindingKey}`] = expression.dateTime.valueOf();
-        queryString +=
-          'NOT ' +
-          matchingSql(
-            `AND "candidate"."created" < to_timestamp(:value_${bindingKey}::decimal / 1000) `,
-          );
-        break;
-      }
-
-      case 'updated after': {
-        const bindingKey = `${prefix}_udaft`;
-        bindings[`value_${bindingKey}`] = expression.dateTime.valueOf();
-        queryString +=
-          'NOT ' +
-          matchingSql(
-            `AND "candidate"."timestamp" < to_timestamp(:value_${bindingKey}::decimal / 1000) `,
-          );
-        break;
-      }
-
-      // Combinators
-
-      case 'not': {
-        const [subQueryString, subQueryBindings] =
-          PGliteDigestPersistenceAdapter.filterQuery(
-            expression.operand,
-            `${prefix}_not`,
-          );
-        queryString += `NOT (${subQueryString}) `;
-        Object.assign(bindings, subQueryBindings);
-        break;
-      }
-
-      case 'and': {
-        const [leftQueryString, leftQueryBindings] =
-          PGliteDigestPersistenceAdapter.filterQuery(
-            expression.left,
-            `${prefix}_and_lt`,
-          );
-        const [rightQueryString, rightQueryBindings] =
-          PGliteDigestPersistenceAdapter.filterQuery(
-            expression.right,
-            `${prefix}_and_rt`,
-          );
-        queryString += `${leftQueryString} AND ${rightQueryString} `;
-        Object.assign(bindings, leftQueryBindings);
-        Object.assign(bindings, rightQueryBindings);
-        break;
-      }
-
-      case 'or': {
-        const [leftQueryString, leftQueryBindings] =
-          PGliteDigestPersistenceAdapter.filterQuery(
-            expression.left,
-            `${prefix}_or_lt`,
-          );
-        const [rightQueryString, rightQueryBindings] =
-          PGliteDigestPersistenceAdapter.filterQuery(
-            expression.right,
-            `${prefix}_or_rt`,
-          );
-        queryString += `${leftQueryString} OR ${rightQueryString} `;
-        Object.assign(bindings, leftQueryBindings);
-        Object.assign(bindings, rightQueryBindings);
-        break;
-      }
-    }
-
-    return [`${queryString}`, bindings];
   }
 
   private async startObservingNewDigestEntries(): Promise<() => Promise<void>> {


### PR DESCRIPTION
## What

Extracts the digest `filterQuery(expression, prefix)` SQL-builder — previously duplicated verbatim in `PostgresDigestPersistenceAdapter` and `PGliteDigestPersistenceAdapter` — into a single exported function in `@telia-oss/xjog-digest-persistence`.

The two copies were confirmed functionally identical (they differed only in a comment and in the class name used for recursive self-calls, both of which disappear on extraction). This is the drift-prone code behind bugs fixed in #55; owning it once removes the drift surface.

## Details

- New `packages/digest-persistence/src/filterQuery.ts`, re-exported from the package index.
- Both adapters call the shared function: pg keeps passing the returned bindings into `bind()`; pglite keeps its positional `:name`→`$N` substitution regex unchanged (still deliberately skips `::` type casts).
- 16 new unit tests for the shared builder (each operator, and/or/not nesting, prefix-unique binding keys).

## Verification

No behavior change. `build` + `test` green across digest-persistence/pg/pglite (existing pglite paging/filter regression tests still pass); `lint` clean. Changeset: `patch` for the three digest packages.

Implements TODO item A1.