### PR TITLE
Extract execution profiling into XJogProfiler; add profiling.enabled (TODO B3)

### DIFF
--- a/.changeset/xjog-profiler.md
+++ b/.changeset/xjog-profiler.md
@@ -1,0 +1,7 @@
+---
+'@telia-oss/xjog': minor
+---
+
+Extract execution profiling into an `XJogProfiler` class and add
+`profiling.enabled` (default true) to allow disabling per-call timing
+overhead.

--- a/packages/core/src/XJog.ts
+++ b/packages/core/src/XJog.ts
@@ -23,7 +23,7 @@ import {
   type StateSchema,
   type Typestate,
 } from 'xstate';
-import { isPromiseLike, toSCXMLEvent } from 'xstate/lib/utils';
+import { toSCXMLEvent } from 'xstate/lib/utils';
 import { XJogActivityManager } from './XJogActivityManager';
 import type { XJogChart } from './XJogChart';
 import { XJogDeferredEventManager } from './XJogDeferredEventManager';
@@ -34,6 +34,7 @@ import {
   resolveXJogOptions,
   type XJogOptions,
 } from './XJogOptions';
+import { XJogProfiler } from './XJogProfiler';
 import { XJogSimulator } from './XJogSimulator';
 import { XJogStartupManager } from './XJogStartupManager';
 
@@ -122,6 +123,12 @@ export class XJog extends XJogLogEmitter {
   public readonly activityManager: XJogActivityManager;
 
   /**
+   * Tracks execution durations for profiling purposes.
+   * @private
+   */
+  private readonly profiler: XJogProfiler;
+
+  /**
    * @param options Options
    */
   constructor(options: XJogOptions) {
@@ -135,6 +142,7 @@ export class XJog extends XJogLogEmitter {
     this.deferredEventManager = new XJogDeferredEventManager(this);
     this.activityManager = new XJogActivityManager(this);
     this.simulator = new XJogSimulator(this);
+    this.profiler = new XJogProfiler(this.options.profiling.enabled);
 
     this.trace('Instance created', {
       instanceId: this.id,
@@ -624,71 +632,8 @@ export class XJog extends XJogLogEmitter {
     });
   }
 
-  // TODO vvv Move these to a monitoring class of its of own. vvv
-
-  private executionDurationHistogramBase = 2;
-  private executionDurationHistogramBuckets = 16;
-
-  private executionDurationHistogramBaseLog = Math.log(
-    this.executionDurationHistogramBase,
-  );
-
-  private executionDurationHistogramBucketCeilingValues = [
-    ...new Array(this.executionDurationHistogramBuckets),
-  ].map((value, index) => this.executionDurationHistogramBase ** index);
-
-  private executionTimes: { [op: string]: number } = {};
-  private executionDurationHistograms: { [op: string]: number[] } = {};
-
-  private getExecutionDurationHistogram(op: string): number[] {
-    if (!this.executionDurationHistograms[op]) {
-      this.executionDurationHistograms[op] = new Array(
-        this.executionDurationHistogramBuckets,
-      ).fill(0);
-    }
-
-    return this.executionDurationHistograms[op];
-  }
-
-  // TODO make option to enable this separately
-  private recordExecutionDuration(op: string, duration: number) {
-    let bucket;
-
-    const ceilingDuration = Math.ceil(duration);
-
-    if (ceilingDuration <= 0) {
-      bucket = 0;
-    } else {
-      bucket = Math.ceil(
-        Math.log(ceilingDuration) / this.executionDurationHistogramBaseLog,
-      );
-    }
-
-    if (bucket >= this.executionDurationHistogramBuckets) {
-      bucket = this.executionDurationHistogramBuckets;
-    }
-
-    this.getExecutionDurationHistogram(op)[bucket]++;
-    this.executionTimes[op] = (this.executionTimes[op] ?? 0) + duration;
-  }
-
   public timeExecution<T>(op: string, routine: () => T): T {
-    // TODO allow enable per options
-
-    const startTime = performance.now();
-    const returnValue = routine();
-
-    const done = () =>
-      this.recordExecutionDuration(op, performance.now() - startTime);
-
-    if (isPromiseLike(returnValue)) {
-      // @ts-expect-error Trust that it has `finally`
-      return returnValue.finally(done) as unknown as T;
-    }
-
-    done();
-
-    return returnValue;
+    return this.profiler.timeExecution(op, routine);
   }
 
   public getProfilingMetrics(): {
@@ -701,26 +646,7 @@ export class XJog extends XJogLogEmitter {
       };
     };
   } {
-    return {
-      buckets: this.executionDurationHistogramBucketCeilingValues,
-      executions: Object.keys(this.executionDurationHistograms)
-        .sort()
-        .reduce((entry, key) => {
-          const histogram = this.executionDurationHistograms[key];
-
-          const count = histogram.reduce((sum, bucket) => sum + bucket, 0);
-          const total = this.executionTimes[key];
-
-          return {
-            ...entry,
-            [key]: {
-              count,
-              total,
-              histogram,
-            },
-          };
-        }, {}),
-    };
+    return this.profiler.getProfilingMetrics();
   }
 
   /**

--- a/packages/core/src/XJogOptions.ts
+++ b/packages/core/src/XJogOptions.ts
@@ -50,6 +50,13 @@ export type XJogOptions = {
      */
     adoptionTimeout?: number;
   };
+  profiling?: {
+    /**
+     * If set to false, `timeExecution` skips timing and histogram bucketing
+     * entirely and just invokes the given routine. Defaults to true.
+     */
+    enabled?: boolean;
+  };
 };
 
 /**
@@ -73,6 +80,9 @@ export type ResolvedXJogOptions = {
   shutdown: {
     ownChartPollingFrequency: number;
     adoptionTimeout: number;
+  };
+  profiling: {
+    enabled: boolean;
   };
 };
 
@@ -100,6 +110,7 @@ export function resolveXJogOptions(
       trace,
     ),
     shutdown: resolveShutdownOptions(options.shutdown, trace),
+    profiling: resolveXJogProfilingOptions(options.profiling, trace),
   };
 }
 
@@ -193,5 +204,20 @@ export function resolveShutdownOptions(
   return {
     ownChartPollingFrequency,
     adoptionTimeout,
+  };
+}
+
+/**
+ * @group XJog
+ * @ignore
+ */
+export function resolveXJogProfilingOptions(
+  options: XJogOptions['profiling'] | undefined | null,
+  trace: (...args: any[]) => void,
+): ResolvedXJogOptions['profiling'] {
+  const enabled = options?.enabled ?? true;
+
+  return {
+    enabled,
   };
 }

--- a/packages/core/src/XJogProfiler.test.ts
+++ b/packages/core/src/XJogProfiler.test.ts
@@ -1,0 +1,58 @@
+import { XJogProfiler } from './XJogProfiler';
+
+describe('XJogProfiler', () => {
+  it('records durations and exposes them via getProfilingMetrics when enabled', async () => {
+    const profiler = new XJogProfiler(true);
+
+    await profiler.timeExecution('op', async () => {
+      // no-op
+    });
+
+    const metrics = profiler.getProfilingMetrics();
+
+    expect(metrics.executions.op).toBeDefined();
+    expect(metrics.executions.op.count).toBe(1);
+    expect(typeof metrics.executions.op.total).toBe('number');
+  });
+
+  it('short-circuits to just invoking the routine when disabled', async () => {
+    const profiler = new XJogProfiler(false);
+
+    const performanceNowSpy = jest.spyOn(performance, 'now');
+
+    const syncResult = profiler.timeExecution('op', () => 42);
+    expect(syncResult).toBe(42);
+
+    const asyncResult = await profiler.timeExecution('op', async () => 'hi');
+    expect(asyncResult).toBe('hi');
+
+    // No timing math should have happened at all.
+    expect(performanceNowSpy).not.toHaveBeenCalled();
+
+    // Nothing should have been recorded either.
+    const metrics = profiler.getProfilingMetrics();
+    expect(metrics.executions).toEqual({});
+
+    performanceNowSpy.mockRestore();
+  });
+
+  it('propagates synchronous throws when disabled', () => {
+    const profiler = new XJogProfiler(false);
+
+    expect(() =>
+      profiler.timeExecution('op', () => {
+        throw new Error('boom');
+      }),
+    ).toThrow('boom');
+  });
+
+  it('propagates async rejections when disabled', async () => {
+    const profiler = new XJogProfiler(false);
+
+    await expect(
+      profiler.timeExecution('op', async () => {
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+  });
+});

--- a/packages/core/src/XJogProfiler.ts
+++ b/packages/core/src/XJogProfiler.ts
@@ -1,0 +1,112 @@
+import { isPromiseLike } from 'xstate/lib/utils';
+
+/**
+ * Tracks execution durations for named operations as log-scaled histograms,
+ * composed into {@link XJog} to keep the profiling machinery isolated from
+ * the rest of the instance's responsibilities.
+ */
+export class XJogProfiler {
+  private readonly enabled: boolean;
+
+  private executionDurationHistogramBase = 2;
+  private executionDurationHistogramBuckets = 16;
+
+  private executionDurationHistogramBaseLog = Math.log(
+    this.executionDurationHistogramBase,
+  );
+
+  private executionDurationHistogramBucketCeilingValues = [
+    ...new Array(this.executionDurationHistogramBuckets),
+  ].map((value, index) => this.executionDurationHistogramBase ** index);
+
+  private executionTimes: { [op: string]: number } = {};
+  private executionDurationHistograms: { [op: string]: number[] } = {};
+
+  constructor(enabled: boolean) {
+    this.enabled = enabled;
+  }
+
+  private getExecutionDurationHistogram(op: string): number[] {
+    if (!this.executionDurationHistograms[op]) {
+      this.executionDurationHistograms[op] = new Array(
+        this.executionDurationHistogramBuckets,
+      ).fill(0);
+    }
+
+    return this.executionDurationHistograms[op];
+  }
+
+  private recordExecutionDuration(op: string, duration: number) {
+    let bucket;
+
+    const ceilingDuration = Math.ceil(duration);
+
+    if (ceilingDuration <= 0) {
+      bucket = 0;
+    } else {
+      bucket = Math.ceil(
+        Math.log(ceilingDuration) / this.executionDurationHistogramBaseLog,
+      );
+    }
+
+    if (bucket >= this.executionDurationHistogramBuckets) {
+      bucket = this.executionDurationHistogramBuckets;
+    }
+
+    this.getExecutionDurationHistogram(op)[bucket]++;
+    this.executionTimes[op] = (this.executionTimes[op] ?? 0) + duration;
+  }
+
+  public timeExecution<T>(op: string, routine: () => T): T {
+    if (!this.enabled) {
+      return routine();
+    }
+
+    const startTime = performance.now();
+    const returnValue = routine();
+
+    const done = () =>
+      this.recordExecutionDuration(op, performance.now() - startTime);
+
+    if (isPromiseLike(returnValue)) {
+      // @ts-expect-error Trust that it has `finally`
+      return returnValue.finally(done) as unknown as T;
+    }
+
+    done();
+
+    return returnValue;
+  }
+
+  public getProfilingMetrics(): {
+    buckets: number[];
+    executions: {
+      [op: string]: {
+        count: number;
+        total: number;
+        histogram: number[];
+      };
+    };
+  } {
+    return {
+      buckets: this.executionDurationHistogramBucketCeilingValues,
+      executions: Object.keys(this.executionDurationHistograms)
+        .sort()
+        .reduce((entry, key) => {
+          const histogram = this.executionDurationHistograms[key];
+
+          const count = histogram.reduce((sum, bucket) => sum + bucket, 0);
+          const total = this.executionTimes[key];
+
+          return {
+            ...entry,
+            [key]: {
+              count,
+              total,
+              histogram,
+            },
+          };
+        }, {}),
+    };
+  }
+}


### PR DESCRIPTION
## What

Moves the execution-duration histogram machinery out of `XJog` into a dedicated `XJogProfiler` class, and adds an `options.profiling.enabled` flag (default `true`) that short-circuits `timeExecution` to just invoke the routine — skipping the `performance.now()` + log-bucket math that currently runs on every timed call system-wide.

## Details

- New `packages/core/src/XJogProfiler.ts` holds the histogram fields/methods; `XJog` composes one and delegates.
- Public API unchanged: `xJog.timeExecution(...)` and `xJog.getProfilingMetrics()` keep identical signatures (used across every core file).
- `profiling.enabled` resolved via the existing raw/resolved options pattern (`enabled ?? true`), so default behavior is preserved exactly.

## Verification

`build` + `test` green (65 tests incl. new `XJogProfiler.test.ts` covering the disabled short-circuit via a `performance.now` spy asserting zero calls, plus sync/async error propagation); `lint` clean. Changeset: `minor` for @telia-oss/xjog.

Implements TODO item B3.