### PR TITLE
Coalesce observeDigests re-queries in XJogDigestReader (TODO C4)

### DIFF
--- a/.changeset/digest-reader-debounce.md
+++ b/.changeset/digest-reader-debounce.md
@@ -1,0 +1,15 @@
+---
+'@telia-oss/xjog-digest-reader': minor
+---
+
+Debounce/coalesce `observeDigests` re-queries so bursts of notifications
+collapse into fewer `queryDigests` calls; window configurable (default 50ms).
+
+This is a behavior change: previously every notification from
+`persistence.newDigestEntriesSubject` triggered an immediate `queryDigests`
+call. Notifications are now buffered for `notificationDebounceMs`
+(default 50ms, configurable via the reader's constructor options) before
+being deduplicated by chart and re-queried, so a burst of notifications for
+the same chart results in a single re-query instead of one per
+notification. The initial `queryDigests` call made when subscribing to
+`observeDigests` is unaffected and still emits immediately.

--- a/packages/digest-reader/jestconfig.js
+++ b/packages/digest-reader/jestconfig.js
@@ -1,0 +1,6 @@
+const baseConfig = require('../jestconfig.base')
+
+module.exports = {
+  ...baseConfig,
+  rootDir: 'src',
+};

--- a/packages/digest-reader/package.json
+++ b/packages/digest-reader/package.json
@@ -27,6 +27,7 @@
     "build:files": "pnpm exec cpx-fixed 'src/**/*.sql' lib",
     "prePublishOnly": "pnpm run build",
     "clean": "rm -rf node_modules lib",
+    "test": "NODE_OPTIONS='--experimental-vm-modules --disable-warning=ExperimentalWarning' pnpm exec jest --config jestconfig.js --passWithNoTests",
     "lint": "pnpm exec biome ci .",
     "lint:fix": "pnpm exec biome check --write .",
     "format": "pnpm exec biome format --write ."

--- a/packages/digest-reader/src/XJogDigestReader.test.ts
+++ b/packages/digest-reader/src/XJogDigestReader.test.ts
@@ -1,0 +1,111 @@
+import type {
+  ChartReferenceWithTimestamp,
+  DigestPersistenceAdapter,
+  DigestQuery,
+} from '@telia-oss/xjog-digest-persistence';
+import type { ChartReference } from '@telia-oss/xjog-util';
+import { Subject } from 'rxjs';
+import { XJogDigestReader } from './XJogDigestReader';
+
+function createPersistence(): DigestPersistenceAdapter & {
+  queryDigests: jest.Mock;
+} {
+  return {
+    type: 'test',
+    newDigestEntriesSubject: new Subject<ChartReference>(),
+    queryDigests: jest.fn(
+      async (query: DigestQuery): Promise<ChartReferenceWithTimestamp[]> => [
+        {
+          machineId: query.machineId ?? 'unknown-machine',
+          chartId: query.chartId ?? 'unknown-chart',
+          timestamp: Date.now(),
+        },
+      ],
+    ),
+  } as unknown as DigestPersistenceAdapter & { queryDigests: jest.Mock };
+}
+
+const baseQuery: DigestQuery = { query: { op: 'eq', left: 'a', right: 'b' } };
+
+// Drains the microtask queue (chained promises from the RxJS/async
+// interop) without advancing any fake timers.
+async function flushMicrotasks(): Promise<void> {
+  for (let i = 0; i < 10; i += 1) {
+    await Promise.resolve();
+  }
+}
+
+describe('XJogDigestReader.observeDigests', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('emits the initial query result immediately, without waiting for the debounce window', async () => {
+    const persistence = createPersistence();
+    const reader = new XJogDigestReader(persistence);
+
+    const received: ChartReferenceWithTimestamp[] = [];
+    reader.observeDigests(baseQuery).subscribe((ref) => received.push(ref));
+
+    // Flush the microtask queue (the initial queryDigests promise)
+    // without advancing any timers - the first result must not wait
+    // for the debounce window.
+    await flushMicrotasks();
+
+    expect(received).toHaveLength(1);
+    expect(persistence.queryDigests).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces a burst of notifications into a single re-query per chart', async () => {
+    const persistence = createPersistence();
+    const reader = new XJogDigestReader(persistence, {
+      notificationDebounceMs: 50,
+    });
+
+    const received: ChartReferenceWithTimestamp[] = [];
+    reader.observeDigests(baseQuery).subscribe((ref) => received.push(ref));
+
+    await flushMicrotasks();
+    expect(persistence.queryDigests).toHaveBeenCalledTimes(1);
+
+    // Burst of notifications for the same chart within the window.
+    persistence.newDigestEntriesSubject.next({
+      machineId: 'm1',
+      chartId: 'c1',
+    });
+    persistence.newDigestEntriesSubject.next({
+      machineId: 'm1',
+      chartId: 'c1',
+    });
+    persistence.newDigestEntriesSubject.next({
+      machineId: 'm1',
+      chartId: 'c1',
+    });
+    // A distinct chart in the same burst must not be dropped.
+    persistence.newDigestEntriesSubject.next({
+      machineId: 'm2',
+      chartId: 'c2',
+    });
+
+    jest.advanceTimersByTime(50);
+    await flushMicrotasks();
+
+    // Only one initial call, plus one call per distinct chart -
+    // the three m1/c1 notifications collapse into a single re-query.
+    expect(persistence.queryDigests).toHaveBeenCalledTimes(3);
+    expect(persistence.queryDigests).toHaveBeenNthCalledWith(2, {
+      ...baseQuery,
+      machineId: 'm1',
+      chartId: 'c1',
+    });
+    expect(persistence.queryDigests).toHaveBeenNthCalledWith(3, {
+      ...baseQuery,
+      machineId: 'm2',
+      chartId: 'c2',
+    });
+  });
+});

--- a/packages/digest-reader/src/XJogDigestReader.ts
+++ b/packages/digest-reader/src/XJogDigestReader.ts
@@ -4,13 +4,34 @@ import type {
   DigestQuery,
 } from '@telia-oss/xjog-digest-persistence';
 import { type ChartReference, XJogLogEmitter } from '@telia-oss/xjog-util';
-import { concat, concatMap, from, type Observable } from 'rxjs';
+import {
+  bufferTime,
+  concat,
+  concatMap,
+  filter,
+  from,
+  type Observable,
+} from 'rxjs';
+import type { XJogDigestReaderOptions } from './XJogDigestReaderOptions';
+import type { XJogDigestReaderResolvedOptions } from './XJogDigestReaderResolvedOptions';
+
+const defaultNotificationDebounceMs = 50;
 
 export class XJogDigestReader extends XJogLogEmitter {
   public readonly component = 'digest/reader';
 
-  constructor(private readonly persistence: DigestPersistenceAdapter) {
+  private readonly options: XJogDigestReaderResolvedOptions;
+
+  constructor(
+    private readonly persistence: DigestPersistenceAdapter,
+    options?: XJogDigestReaderOptions,
+  ) {
     super();
+
+    this.options = {
+      notificationDebounceMs:
+        options?.notificationDebounceMs ?? defaultNotificationDebounceMs,
+    };
   }
 
   public async queryDigests(
@@ -28,6 +49,15 @@ export class XJogDigestReader extends XJogLogEmitter {
         concatMap((refs: ChartReferenceWithTimestamp[]) => refs),
       ),
       from(this.persistence.newDigestEntriesSubject).pipe(
+        // Coalesce bursts of notifications into batches so that many
+        // notifications arriving in quick succession trigger fewer
+        // `queryDigests` calls. Each batch is deduplicated by
+        // machineId/chartId before re-querying, so no distinct chart
+        // notification is dropped - only redundant re-queries for the
+        // same chart within the window are collapsed.
+        bufferTime(this.options.notificationDebounceMs),
+        filter((refs: ChartReference[]) => refs.length > 0),
+        concatMap((refs: ChartReference[]) => dedupeRefs(refs)),
         concatMap((ref: ChartReference) => {
           return this.persistence.queryDigests({
             ...query,
@@ -40,4 +70,12 @@ export class XJogDigestReader extends XJogLogEmitter {
       ),
     );
   }
+}
+
+function dedupeRefs(refs: ChartReference[]): ChartReference[] {
+  const seen = new Map<string, ChartReference>();
+  for (const ref of refs) {
+    seen.set(`${ref.machineId}:${ref.chartId}`, ref);
+  }
+  return [...seen.values()];
 }

--- a/packages/digest-reader/src/XJogDigestReaderOptions.ts
+++ b/packages/digest-reader/src/XJogDigestReaderOptions.ts
@@ -1,0 +1,9 @@
+export type XJogDigestReaderOptions = {
+  /**
+   * Notifications for new digest entries are buffered for this many
+   * milliseconds before triggering a re-query, so that a burst of
+   * notifications collapses into a single `queryDigests` call per
+   * distinct chart. Defaults to 50ms.
+   */
+  notificationDebounceMs?: number;
+};

--- a/packages/digest-reader/src/XJogDigestReaderResolvedOptions.ts
+++ b/packages/digest-reader/src/XJogDigestReaderResolvedOptions.ts
@@ -1,0 +1,3 @@
+export type XJogDigestReaderResolvedOptions = {
+  notificationDebounceMs: number;
+};

--- a/packages/digest-reader/src/index.ts
+++ b/packages/digest-reader/src/index.ts
@@ -1,1 +1,2 @@
 export * from './XJogDigestReader';
+export * from './XJogDigestReaderOptions';


### PR DESCRIPTION
## What

`XJogDigestReader.observeDigests` re-ran `persistence.queryDigests()` on every notification. This coalesces bursts so many notifications trigger fewer re-queries.

## Details

- Uses RxJS `bufferTime(window)` + dedupe-by-`machineId:chartId` rather than `debounceTime`/`auditTime`: the notification stream carries per-chart refs, so a plain debounce would silently **drop** notifications for every chart except the last in a burst. Buffering + dedupe collapses repeat notifications for the *same* chart to one query while still querying each distinct chart exactly once (no data loss).
- Window is configurable via a new `notificationDebounceMs` option (default 50ms), following the existing reader options pattern.
- The initial query stays on the un-buffered `concat` arm, so first results are not delayed.

## Verification

Behavior change (documented in the changeset). Added jest fake-timer tests (immediate first emission; a 3+1 notification burst collapses to 2 re-queries). `build` + `test` green; `lint` clean. Changeset: `minor` for @telia-oss/xjog-digest-reader.

Implements TODO item C4.