### PR TITLE
Split XJogChart.send() tail into helpers (TODO B2)

### DIFF
--- a/.changeset/split-send-tail.md
+++ b/.changeset/split-send-tail.md
@@ -1,0 +1,5 @@
+---
+"@telia-oss/xjog": patch
+---
+
+Extract the simulator-interception block and the done-state/auto-forward tail of `XJogChart.send()` into private helpers (no behavior change); the mutex/transition core is untouched.

--- a/packages/core/src/XJogChart.ts
+++ b/packages/core/src/XJogChart.ts
@@ -660,6 +660,60 @@ export class XJogChart<
   }
 
   /**
+   * Dev only: if a simulation rule matches the given event, short-circuits
+   * `send()` by skipping the event, simulating a failure, or delaying it.
+   *
+   * Returns a discriminated result: `{ intercepted: true, result }` means
+   * `send()` must return `result` immediately; `{ intercepted: false }` means
+   * `send()` should proceed as normal.
+   */
+  private async interceptWithSimulator(
+    event: Event<TEvent> | SCXML.Event<TEvent>,
+    scxmlEvent: SCXML.Event<TEvent>,
+    warn: (...args: Array<string | Record<string, unknown>>) => void,
+  ): Promise<{ intercepted: true; result: null } | { intercepted: false }> {
+    if (!this.xJog.simulator.isEnabled()) {
+      return { intercepted: false };
+    }
+
+    const eventName = scxmlEvent.name;
+    const getMatchingRule = (action: SimulatorAction) => {
+      const rule = this.xJog.simulator.matchesRule({
+        event: eventName,
+        action,
+      });
+      if (rule) {
+        warn({
+          message: `Matched simulation rule, will ${rule.action} event ${event}`,
+          eventName,
+          rule,
+        });
+        return rule;
+      }
+      return null;
+    };
+
+    if (getMatchingRule('skip')) {
+      return { intercepted: true, result: null };
+    }
+
+    if (getMatchingRule('fail')) {
+      throw new Error(`Simulated failure for event ${eventName}`);
+    }
+
+    const delayRule = getMatchingRule('delay');
+    if (delayRule) {
+      // Assume the value is in milliseconds and delay of the event
+      const delay = parseInt(delayRule.value ?? '0');
+      if (!Number.isNaN(delay)) {
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+
+    return { intercepted: false };
+  }
+
+  /**
    * @param event XState event to send.
    * @param context Fields to patch the context. Either an object or an updater callback function.
    *   can be called. The callback is called with the context read from the database, and it must
@@ -688,41 +742,13 @@ export class XJogChart<
     return this.xJog.timeExecution('chart.send', async () => {
       const scxmlEvent = toSCXMLEvent(event);
 
-      // Dev only: If a simulation rule matches, ignore the event
-      if (this.xJog.simulator.isEnabled()) {
-        const eventName = scxmlEvent.name;
-        const getMatchingRule = (action: SimulatorAction) => {
-          const rule = this.xJog.simulator.matchesRule({
-            event: eventName,
-            action,
-          });
-          if (rule) {
-            warn({
-              message: `Matched simulation rule, will ${rule.action} event ${event}`,
-              eventName,
-              rule,
-            });
-            return rule;
-          }
-          return null;
-        };
-
-        if (getMatchingRule('skip')) {
-          return null;
-        }
-
-        if (getMatchingRule('fail')) {
-          throw new Error(`Simulated failure for event ${eventName}`);
-        }
-
-        const delayRule = getMatchingRule('delay');
-        if (delayRule) {
-          // Assume the value is in milliseconds and delay of the event
-          const delay = parseInt(delayRule.value ?? '0');
-          if (!Number.isNaN(delay)) {
-            await new Promise((resolve) => setTimeout(resolve, delay));
-          }
-        }
+      const simulatorInterception = await this.interceptWithSimulator(
+        event,
+        scxmlEvent,
+        warn,
+      );
+      if (simulatorInterception.intercepted) {
+        return simulatorInterception.result;
       }
 
       trace({ message: 'Sending event', eventName: scxmlEvent.name });
@@ -854,38 +880,58 @@ export class XJogChart<
         await releaseMutex();
       }
 
-      if (this.state.done && this.parentRef) {
-        // Best-effort: the transition is already committed and the mutex
-        // released by this point, so a throwing final-state `data` mapper (or
-        // resolveDoneData failing to locate the final node) must not reject
-        // send() — that would report a hard failure for a transition that
-        // actually succeeded. Log and skip the parent notification instead.
-        try {
-          trace({ message: 'Final state reached' });
-          const doneData = await this.resolveDoneData(this.state, cid);
-
-          trace({ message: 'Notifying the owner that chart is done' });
-
-          // TODO should probably defer this event
-          await this.xJog.sendEvent(
-            this.parentRef,
-            doneInvoke(this.id, doneData),
-            undefined,
-            undefined,
-            cid,
-          );
-        } catch (err) {
-          error('Failed to notify owner that chart is done', { err });
-        }
-      }
+      await this.notifyOwnerIfDone(trace, error, cid);
 
       trace({ message: 'Done' });
 
-      this.xJog.timeExecution('chart.send.auto-forward', () => {
-        this.xJog.activityManager.sendAutoForwardEvent(this.ref, scxmlEvent);
-      });
+      this.autoForwardToChildren(scxmlEvent);
 
       return this.state;
+    });
+  }
+
+  /**
+   * If the chart reached a final state and has an owning parent, resolve the
+   * done data and notify the parent via a done-invoke event.
+   *
+   * Best-effort: the transition is already committed and the mutex released
+   * by this point, so a throwing final-state `data` mapper (or
+   * resolveDoneData failing to locate the final node) must not reject
+   * send() — that would report a hard failure for a transition that actually
+   * succeeded. Log and skip the parent notification instead.
+   */
+  private async notifyOwnerIfDone(
+    trace: (...args: Array<string | Record<string, unknown>>) => void,
+    error: (...args: Array<string | Record<string, unknown>>) => void,
+    cid: string,
+  ): Promise<void> {
+    if (!this.state.done || !this.parentRef) {
+      return;
+    }
+
+    try {
+      trace({ message: 'Final state reached' });
+      const doneData = await this.resolveDoneData(this.state, cid);
+
+      trace({ message: 'Notifying the owner that chart is done' });
+
+      // TODO should probably defer this event
+      await this.xJog.sendEvent(
+        this.parentRef,
+        doneInvoke(this.id, doneData),
+        undefined,
+        undefined,
+        cid,
+      );
+    } catch (err) {
+      error('Failed to notify owner that chart is done', { err });
+    }
+  }
+
+  /** Forwards the sent event to activities configured for auto-forwarding. */
+  private autoForwardToChildren(scxmlEvent: SCXML.Event<TEvent>): void {
+    this.xJog.timeExecution('chart.send.auto-forward', () => {
+      this.xJog.activityManager.sendAutoForwardEvent(this.ref, scxmlEvent);
     });
   }
 


### PR DESCRIPTION
## What

Extracts the two peripheral blocks of `XJogChart.send()` into named private helpers, leaving the mutex/transition core — the riskiest code in the repo — byte-for-byte untouched. **Zero behavior change.** Builds on #63 (B1).

## Details

- `interceptWithSimulator(event, scxmlEvent, warn)` — the dev-only simulator-interception block from the top of `send()`. Returns a discriminated `{ intercepted: true, result: null } | { intercepted: false }`; `send()` does `if (r.intercepted) return r.result;`. Preserves the exact short-circuits: `skip` → return `null`, `fail` → throw, `delay` → await then continue.
- `notifyOwnerIfDone(trace, error, cid)` — the done-state parent notification (final-state `resolveDoneData` + `doneInvoke`), awaited at the same point right after the mutex `finally`. Guard inverted to an early-return but logically identical; best-effort try/catch preserved.
- `autoForwardToChildren(scxmlEvent)` — the trailing non-awaited `timeExecution('chart.send.auto-forward', …)` call, invoked at the same point before `return this.state`.
- The middle mutex/transition section does not appear in the diff — untouched.

## Verification

Self-reviewed for early-return value, await ordering, and helper invocation points relative to the mutex release — all preserved. `build` + `test` green (`XJogChart.test.ts` passes unchanged); `lint` clean. Changeset: `patch` for @telia-oss/xjog.

Implements TODO item B2.