### PR TITLE
Add real-Postgres driver smoke tests + CI job (TODO A5)

### DIFF
--- a/.changeset/digest-pg-connect-release.md
+++ b/.changeset/digest-pg-connect-release.md
@@ -1,0 +1,5 @@
+---
+'@telia-oss/xjog-digest-pg': patch
+---
+
+Release the connection-check client in `PostgresDigestPersistenceAdapter.connect()`; the unreleased client permanently occupied a pool slot and made `disconnect()` hang forever waiting for `pool.end()`.

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -66,3 +66,66 @@ jobs:
         # runner starves them into 5s test timeouts. One package at a time keeps
         # each suite fast. Local dev keeps full turbo concurrency.
         run: pnpm exec turbo run test --concurrency=1
+
+  pg-smoke:
+    name: Postgres driver smoke tests
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      PG_TEST_URL: postgres://postgres:postgres@localhost:5432/postgres
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 1
+
+      - name: Setup pnpm
+        # Version comes from the packageManager field in package.json.
+        uses: pnpm/action-setup@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          pnpm install --frozen-lockfile
+
+      - name: Run build
+        # Needed so lib/migrations/*.sql exist for the -pg adapters' connect().
+        run: pnpm exec turbo run build
+
+      - name: Run Postgres driver smoke tests
+        # Only the three -pg suites; everything else is covered by `check`.
+        # Serialized so the three suites don't create/drop databases on the
+        # same Postgres server concurrently.
+        run: |
+          pnpm exec turbo run test \
+            --filter=./packages/core-pg \
+            --filter=./packages/journal-pg \
+            --filter=./packages/digest-pg \
+            --concurrency=1

--- a/packages/core-pg/jest.config.js
+++ b/packages/core-pg/jest.config.js
@@ -1,0 +1,6 @@
+const baseConfig = require('../jestconfig.base');
+
+module.exports = {
+  ...baseConfig,
+  rootDir: 'src',
+};

--- a/packages/core-pg/package.json
+++ b/packages/core-pg/package.json
@@ -29,7 +29,8 @@
 		"clean": "rm -rf node_modules lib",
 		"lint": "pnpm exec biome ci .",
 		"lint:fix": "pnpm exec biome check --write .",
-		"format": "pnpm exec biome format --write ."
+		"format": "pnpm exec biome format --write .",
+		"test": "NODE_OPTIONS='--experimental-vm-modules --disable-warning=ExperimentalWarning' pnpm exec jest"
 	},
 	"dependencies": {
 		"@telia-oss/xjog-core-persistence": "workspace:^",

--- a/packages/core-pg/src/PostgresPersistenceAdapter.smoke.test.ts
+++ b/packages/core-pg/src/PostgresPersistenceAdapter.smoke.test.ts
@@ -1,0 +1,138 @@
+import { randomUUID } from 'node:crypto';
+import type { PoolConfig } from 'pg';
+import { Client } from 'pg';
+import { State } from 'xstate';
+import { PostgresPersistenceAdapter } from './PostgresPersistenceAdapter';
+
+// `pg`'s Pool/Client give `connectionString` priority over any co-supplied
+// discrete fields (e.g. `database`), so `{ connectionString, database }`
+// silently connects to the database named in the string, not the override.
+// Parse the string into discrete fields so the per-suite `database` override
+// in `poolConfigFor` actually takes effect.
+function basePoolConfigFromConnectionString(raw: string): PoolConfig {
+  const url = new URL(raw);
+  return {
+    host: url.hostname,
+    port: url.port ? Number(url.port) : undefined,
+    user: decodeURIComponent(url.username),
+    password: decodeURIComponent(url.password),
+    database: decodeURIComponent(url.pathname.replace(/^\//, '')),
+  };
+}
+
+// These tests exercise the real node-postgres driver against a real
+// Postgres server: connection pooling, migrations, and transactions. This
+// is exactly what the PGlite suites cannot cover, since they run against an
+// in-process WASM database rather than the `pg` driver.
+//
+// They require a reachable Postgres server. Point PG_TEST_URL (or
+// DATABASE_URL) at one to run them; otherwise the whole suite is skipped so
+// `pnpm test`/CI `check` stay dependency-free.
+const connectionString = process.env.PG_TEST_URL ?? process.env.DATABASE_URL;
+
+const describePg = connectionString ? describe : describe.skip;
+
+describePg('PostgresPersistenceAdapter (real Postgres)', () => {
+  const databaseName = `xjog_core_pg_smoke_${randomUUID().replace(/-/g, '')}`;
+  // describe.skip still invokes this callback to collect the (skipped)
+  // tests, so this must not throw when connectionString is unset.
+  const baseConfig = connectionString
+    ? basePoolConfigFromConnectionString(connectionString)
+    : ({} as PoolConfig);
+  let poolConfiguration: PoolConfig;
+  let adapter: PostgresPersistenceAdapter;
+
+  beforeAll(async () => {
+    // Connect to the base database to create a fresh, isolated database for
+    // this suite. node-pg-migrate tracks applied migrations in a table, so
+    // sharing a database across the three -pg suites would collide.
+    const adminClient = new Client(baseConfig);
+    await adminClient.connect();
+    try {
+      await adminClient.query(`CREATE DATABASE "${databaseName}"`);
+    } finally {
+      await adminClient.end();
+    }
+
+    poolConfiguration = { ...baseConfig, database: databaseName };
+
+    adapter = await PostgresPersistenceAdapter.connect(poolConfiguration);
+  }, 30_000);
+
+  afterAll(async () => {
+    await adapter?.disconnect();
+
+    const adminClient = new Client(baseConfig);
+    await adminClient.connect();
+    try {
+      await adminClient.query(
+        `DROP DATABASE IF EXISTS "${databaseName}" WITH (FORCE)`,
+      );
+    } finally {
+      await adminClient.end();
+    }
+  }, 30_000);
+
+  it('connects and applies migrations without throwing', async () => {
+    expect(adapter).toBeDefined();
+
+    const result = await adapter.withTransaction(async (client) =>
+      client.query(
+        `SELECT to_regclass('"charts"') AS "charts", ` +
+          `to_regclass('"instances"') AS "instances"`,
+      ),
+    );
+
+    expect(result.rows[0].charts).toBe('charts');
+    expect(result.rows[0].instances).toBe('instances');
+  }, 10_000);
+
+  it('withTransaction commits a write that becomes visible afterwards', async () => {
+    const ref = { machineId: 'smoke-machine', chartId: 'commit-chart' };
+
+    await adapter.withTransaction(async (client) => {
+      await client.query(
+        'INSERT INTO "charts" ' +
+          '("ownerId", "machineId", "chartId", "state") ' +
+          "VALUES ($1, $2, $3, decode('7b7d', 'hex'))",
+        ['owner', ref.machineId, ref.chartId],
+      );
+    });
+
+    expect(await adapter.isChartPresent(ref)).toBe(true);
+  }, 10_000);
+
+  it('withTransaction rolls back when the routine throws', async () => {
+    const ref = { machineId: 'smoke-machine', chartId: 'rollback-chart' };
+
+    await expect(
+      adapter.withTransaction(async (client) => {
+        await client.query(
+          'INSERT INTO "charts" ' +
+            '("ownerId", "machineId", "chartId", "state") ' +
+            "VALUES ($1, $2, $3, decode('7b7d', 'hex'))",
+          ['owner', ref.machineId, ref.chartId],
+        );
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    expect(await adapter.isChartPresent(ref)).toBe(false);
+  }, 10_000);
+
+  it('destroyChart removes a previously created chart', async () => {
+    const ref = { machineId: 'smoke-machine', chartId: 'destroy-chart' };
+
+    await adapter.createChart(
+      'owner',
+      ref,
+      State.from('idle', {}),
+      null,
+      'cid-smoke-destroy',
+    );
+    expect(await adapter.isChartPresent(ref)).toBe(true);
+
+    await adapter.destroyChart(ref, 'cid-smoke-destroy');
+    expect(await adapter.isChartPresent(ref)).toBe(false);
+  }, 10_000);
+});

--- a/packages/digest-pg/jest.config.js
+++ b/packages/digest-pg/jest.config.js
@@ -1,0 +1,6 @@
+const baseConfig = require('../jestconfig.base');
+
+module.exports = {
+  ...baseConfig,
+  rootDir: 'src',
+};

--- a/packages/digest-pg/package.json
+++ b/packages/digest-pg/package.json
@@ -29,7 +29,8 @@
 		"clean": "rm -rf node_modules lib",
 		"lint": "pnpm exec biome ci .",
 		"lint:fix": "pnpm exec biome check --write .",
-		"format": "pnpm exec biome format --write ."
+		"format": "pnpm exec biome format --write .",
+		"test": "NODE_OPTIONS='--experimental-vm-modules --disable-warning=ExperimentalWarning' pnpm exec jest"
 	},
 	"dependencies": {
 		"@telia-oss/xjog-digest-persistence": "workspace:^",

--- a/packages/digest-pg/src/PostgresDigestPersistenceAdapter.smoke.test.ts
+++ b/packages/digest-pg/src/PostgresDigestPersistenceAdapter.smoke.test.ts
@@ -1,0 +1,117 @@
+import { randomUUID } from 'node:crypto';
+import type { ChartReference } from '@telia-oss/xjog-util';
+import type { PoolConfig } from 'pg';
+import { Client } from 'pg';
+import { PostgresDigestPersistenceAdapter } from './PostgresDigestPersistenceAdapter';
+
+// `pg`'s Pool/Client give `connectionString` priority over any co-supplied
+// discrete fields (e.g. `database`), so `{ connectionString, database }`
+// silently connects to the database named in the string, not the override.
+// Parse the string into discrete fields so the per-suite `database` override
+// below actually takes effect.
+function basePoolConfigFromConnectionString(raw: string): PoolConfig {
+  const url = new URL(raw);
+  return {
+    host: url.hostname,
+    port: url.port ? Number(url.port) : undefined,
+    user: decodeURIComponent(url.username),
+    password: decodeURIComponent(url.password),
+    database: decodeURIComponent(url.pathname.replace(/^\//, '')),
+  };
+}
+
+// These tests exercise the real node-postgres driver and pg-listen against a
+// real Postgres server: connection pooling, migrations, and a real
+// LISTEN/NOTIFY round trip. This is exactly what the PGlite suite cannot
+// cover, since PGlite has no separate server process to NOTIFY through.
+//
+// They require a reachable Postgres server. Point PG_TEST_URL (or
+// DATABASE_URL) at one to run them; otherwise the whole suite is skipped so
+// `pnpm test`/CI `check` stay dependency-free.
+const connectionString = process.env.PG_TEST_URL ?? process.env.DATABASE_URL;
+
+const describePg = connectionString ? describe : describe.skip;
+
+describePg('PostgresDigestPersistenceAdapter (real Postgres)', () => {
+  const databaseName = `xjog_digest_pg_smoke_${randomUUID().replace(/-/g, '')}`;
+  // describe.skip still invokes this callback to collect the (skipped)
+  // tests, so this must not throw when connectionString is unset.
+  const baseConfig = connectionString
+    ? basePoolConfigFromConnectionString(connectionString)
+    : ({} as PoolConfig);
+  let poolConfiguration: PoolConfig;
+  let adapter: PostgresDigestPersistenceAdapter;
+
+  beforeAll(async () => {
+    // Isolated, per-suite database: node-pg-migrate tracks applied
+    // migrations in a table, so sharing a database across the three -pg
+    // suites would collide.
+    const adminClient = new Client(baseConfig);
+    await adminClient.connect();
+    try {
+      await adminClient.query(`CREATE DATABASE "${databaseName}"`);
+    } finally {
+      await adminClient.end();
+    }
+
+    poolConfiguration = { ...baseConfig, database: databaseName };
+
+    adapter = await PostgresDigestPersistenceAdapter.connect(poolConfiguration);
+  }, 30_000);
+
+  afterAll(async () => {
+    await adapter?.disconnect();
+
+    const adminClient = new Client(baseConfig);
+    await adminClient.connect();
+    try {
+      await adminClient.query(
+        `DROP DATABASE IF EXISTS "${databaseName}" WITH (FORCE)`,
+      );
+    } finally {
+      await adminClient.end();
+    }
+  }, 30_000);
+
+  it('connects and applies migrations without throwing', async () => {
+    expect(adapter).toBeDefined();
+
+    const ref: ChartReference = { machineId: 'smoke-machine', chartId: 'x' };
+    const digest = await adapter.readDigest(ref, 'nonexistent');
+    expect(digest).toBeNull();
+  }, 10_000);
+
+  it('emits a digest notification through a real LISTEN/NOTIFY round trip', async () => {
+    const ref: ChartReference = {
+      machineId: 'smoke-machine',
+      chartId: 'listen-notify-chart',
+    };
+
+    // Subscribe before writing so the emission cannot be missed.
+    const nextNotification = new Promise<ChartReference>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error('Timed out waiting for a digest notification')),
+        10_000,
+      );
+      const subscription = adapter.newDigestEntriesSubject.subscribe({
+        next: (notifiedRef) => {
+          clearTimeout(timer);
+          subscription.unsubscribe();
+          resolve(notifiedRef);
+        },
+        error: (err) => {
+          clearTimeout(timer);
+          reject(err);
+        },
+      });
+    });
+
+    await adapter.record(ref, { foo: 'bar' });
+
+    const notifiedRef = await nextNotification;
+    expect(notifiedRef).toEqual(ref);
+
+    const digest = await adapter.readDigest(ref, 'foo');
+    expect(digest).toMatchObject({ key: 'foo', value: 'bar', ref });
+  }, 15_000);
+});

--- a/packages/digest-pg/src/PostgresDigestPersistenceAdapter.ts
+++ b/packages/digest-pg/src/PostgresDigestPersistenceAdapter.ts
@@ -39,7 +39,12 @@ export class PostgresDigestPersistenceAdapter extends AbstractPostgresDigestPers
     poolConfiguration: PoolConfig,
   ): Promise<PostgresDigestPersistenceAdapter> {
     const pool = new Pool(poolConfiguration);
-    await pool.connect();
+    // Verify the pool can actually establish a connection before returning,
+    // but release it immediately: an unreleased client here permanently
+    // occupies a pool slot and causes pool.end() (called from disconnect())
+    // to hang forever, since the pool waits for every checked-out client to
+    // be released before it can close.
+    (await pool.connect()).release();
 
     const adapter = new PostgresDigestPersistenceAdapter(
       poolConfiguration,

--- a/packages/journal-pg/jest.config.js
+++ b/packages/journal-pg/jest.config.js
@@ -1,0 +1,6 @@
+const baseConfig = require('../jestconfig.base');
+
+module.exports = {
+  ...baseConfig,
+  rootDir: 'src',
+};

--- a/packages/journal-pg/package.json
+++ b/packages/journal-pg/package.json
@@ -29,7 +29,8 @@
 		"clean": "rm -rf node_modules lib",
 		"lint": "pnpm exec biome ci .",
 		"lint:fix": "pnpm exec biome check --write .",
-		"format": "pnpm exec biome format --write ."
+		"format": "pnpm exec biome format --write .",
+		"test": "NODE_OPTIONS='--experimental-vm-modules --disable-warning=ExperimentalWarning' pnpm exec jest"
 	},
 	"dependencies": {
 		"@telia-oss/xjog-core-persistence": "workspace:^",

--- a/packages/journal-pg/src/PostgresJournalPersistenceAdapter.smoke.test.ts
+++ b/packages/journal-pg/src/PostgresJournalPersistenceAdapter.smoke.test.ts
@@ -1,0 +1,128 @@
+import { randomUUID } from 'node:crypto';
+import type { JournalEntry } from '@telia-oss/xjog-journal-persistence';
+import type { XJogStateChangeAction } from '@telia-oss/xjog-util';
+import type { PoolConfig } from 'pg';
+import { Client } from 'pg';
+import { PostgresJournalPersistenceAdapter } from './PostgresJournalPersistenceAdapter';
+
+// `pg`'s Pool/Client give `connectionString` priority over any co-supplied
+// discrete fields (e.g. `database`), so `{ connectionString, database }`
+// silently connects to the database named in the string, not the override.
+// Parse the string into discrete fields so the per-suite `database` override
+// below actually takes effect.
+function basePoolConfigFromConnectionString(raw: string): PoolConfig {
+  const url = new URL(raw);
+  return {
+    host: url.hostname,
+    port: url.port ? Number(url.port) : undefined,
+    user: decodeURIComponent(url.username),
+    password: decodeURIComponent(url.password),
+    database: decodeURIComponent(url.pathname.replace(/^\//, '')),
+  };
+}
+
+// These tests exercise the real node-postgres driver and pg-listen against a
+// real Postgres server: connection pooling, migrations, and a real
+// LISTEN/NOTIFY round trip. This is exactly what the PGlite suite cannot
+// cover, since PGlite has no separate server process to NOTIFY through.
+//
+// They require a reachable Postgres server. Point PG_TEST_URL (or
+// DATABASE_URL) at one to run them; otherwise the whole suite is skipped so
+// `pnpm test`/CI `check` stay dependency-free.
+const connectionString = process.env.PG_TEST_URL ?? process.env.DATABASE_URL;
+
+const describePg = connectionString ? describe : describe.skip;
+
+describePg('PostgresJournalPersistenceAdapter (real Postgres)', () => {
+  const databaseName = `xjog_journal_pg_smoke_${randomUUID().replace(/-/g, '')}`;
+  // describe.skip still invokes this callback to collect the (skipped)
+  // tests, so this must not throw when connectionString is unset.
+  const baseConfig = connectionString
+    ? basePoolConfigFromConnectionString(connectionString)
+    : ({} as PoolConfig);
+  let poolConfiguration: PoolConfig;
+  let adapter: PostgresJournalPersistenceAdapter;
+
+  beforeAll(async () => {
+    // Isolated, per-suite database: node-pg-migrate tracks applied
+    // migrations in a table, so sharing a database across the three -pg
+    // suites would collide.
+    const adminClient = new Client(baseConfig);
+    await adminClient.connect();
+    try {
+      await adminClient.query(`CREATE DATABASE "${databaseName}"`);
+    } finally {
+      await adminClient.end();
+    }
+
+    poolConfiguration = { ...baseConfig, database: databaseName };
+
+    adapter =
+      await PostgresJournalPersistenceAdapter.connect(poolConfiguration);
+  }, 30_000);
+
+  afterAll(async () => {
+    await adapter?.disconnect();
+
+    const adminClient = new Client(baseConfig);
+    await adminClient.connect();
+    try {
+      await adminClient.query(
+        `DROP DATABASE IF EXISTS "${databaseName}" WITH (FORCE)`,
+      );
+    } finally {
+      await adminClient.end();
+    }
+  }, 30_000);
+
+  it('connects and applies migrations without throwing', async () => {
+    expect(adapter).toBeDefined();
+
+    const entry = await adapter.readEntry(1);
+    expect(entry).toBeNull();
+  }, 10_000);
+
+  it('emits a journal-entry notification through a real LISTEN/NOTIFY round trip', async () => {
+    const ref = { machineId: 'smoke-machine', chartId: 'listen-notify-chart' };
+    const actions: XJogStateChangeAction[] = [];
+
+    // Subscribe before writing so the emission cannot be missed.
+    const nextEntry = new Promise<JournalEntry>((resolve, reject) => {
+      const timer = setTimeout(
+        () =>
+          reject(
+            new Error('Timed out waiting for a journal entry notification'),
+          ),
+        10_000,
+      );
+      const subscription = adapter.newJournalEntries({ ref }).subscribe({
+        next: (entry) => {
+          clearTimeout(timer);
+          subscription.unsubscribe();
+          resolve(entry);
+        },
+        error: (err) => {
+          clearTimeout(timer);
+          reject(err);
+        },
+      });
+    });
+
+    await adapter.record(
+      'owner',
+      ref,
+      null,
+      { type: 'smoke-event' },
+      null,
+      null,
+      { state: 'new' },
+      { ctx: 'new' },
+      actions,
+      'cid-smoke-listen',
+    );
+
+    const entry = await nextEntry;
+    expect(entry.ref).toEqual(ref);
+    expect(entry.event).toEqual({ type: 'smoke-event' });
+  }, 15_000);
+});

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,8 @@
     },
     "test": {
       "dependsOn": ["^build"],
-      "outputs": []
+      "outputs": [],
+      "env": ["PG_TEST_URL", "DATABASE_URL"]
     },
     "lint": {
       "dependsOn": []


### PR DESCRIPTION
## What

Completes Track A. The `-pg` packages had zero tests; after #64/#66/#67 all shared SQL is covered by the PGlite suites, leaving only the driver layer uncovered. This adds small real-Postgres smoke suites for `core-pg`, `journal-pg`, and `digest-pg`, plus a `pg-smoke` CI job.

## Details

- **Env-guarded**: suites read `PG_TEST_URL ?? DATABASE_URL` and `describe.skip` themselves when unset — local `pnpm test` and the existing `check` job stay dependency-free (verified: 8 skipped, tasks green).
- **Per-suite DB isolation**: each suite creates `xjog_<pkg>_smoke_<uuid>`, runs the adapter's `connect()` (migrations) against it, and drops it in `afterAll` — no `node-pg-migrate` tracking-table collisions between suites on a shared server. Connection strings are parsed into discrete `PoolConfig` fields because `pg` silently ignores a `database` override when `connectionString` is present.
- **Coverage**: core-pg — connect + migrations, `withTransaction` commit **and** rollback, `destroyChart`; journal-pg + digest-pg — connect + migrations and a real `pg-listen` → `pg_notify` LISTEN/NOTIFY round trip each.
- **CI**: new `pg-smoke` job in `check-pr.yml` with a `postgres:16-alpine` service container (health-checked), building first (adapters load `lib/migrations/*.sql`), then running only the three `-pg` suites serialized. The existing `check` job is unchanged. `turbo.json` declares `PG_TEST_URL`/`DATABASE_URL` in the test task's `env` so turbo doesn't serve stale cached results across env changes.

## 🐛 Real bug found and fixed by these tests

`digest-pg`'s `connect()` did `await pool.connect()` and discarded the client without releasing it — permanently occupying a pool slot, so `disconnect()` → `pool.end()` hangs forever. Fixed with `(await pool.connect()).release()`. The hang was reproduced before the fix and confirmed resolved after (the digest suite's teardown is the regression test — it hangs without the fix). Changeset: `patch` for `@telia-oss/xjog-digest-pg`.

## Verification

All 8 tests run green against real Postgres 16 on **two independent local setups** (a Homebrew postgres@16 server and a `postgres:16-alpine` Docker container), including both LISTEN/NOTIFY round trips. Skip path verified with env unset. Full-repo build (15/15) + test (16/16) + `lint` clean.

Implements TODO item A5 — Track A complete.