### PR TITLE
fix(journal-pg): serialize notification reads on shared read connection

### DIFF
--- a/.changeset/serialize-journal-notification-reads.md
+++ b/.changeset/serialize-journal-notification-reads.md
@@ -1,9 +1,0 @@
----
-'@telia-oss/xjog-journal-pg': patch
----
-
-Serialize the two reads in the journal-entry notification handler. Both
-`queryEntries` and `queryFullStates` route through `runReadQuery` on the single
-shared read connection, and a `pg.Client` can only execute one query at a time.
-Firing them in parallel triggered pg's "client is already executing a query"
-deprecation warning (a hard throw in pg@9). They are now awaited sequentially.

--- a/.changeset/serialize-journal-notification-reads.md
+++ b/.changeset/serialize-journal-notification-reads.md
@@ -1,0 +1,9 @@
+---
+'@telia-oss/xjog-journal-pg': patch
+---
+
+Serialize the two reads in the journal-entry notification handler. Both
+`queryEntries` and `queryFullStates` route through `runReadQuery` on the single
+shared read connection, and a `pg.Client` can only execute one query at a time.
+Firing them in parallel triggered pg's "client is already executing a query"
+deprecation warning (a hard throw in pg@9). They are now awaited sequentially.

--- a/packages/journal-pg/CHANGELOG.md
+++ b/packages/journal-pg/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @telia-oss/xjog-journal-pg
 
+## 0.3.1
+
+### Patch Changes
+
+- 8245860: Serialize the two reads in the journal-entry notification handler. Both
+  `queryEntries` and `queryFullStates` route through `runReadQuery` on the single
+  shared read connection, and a `pg.Client` can only execute one query at a time.
+  Firing them in parallel triggered pg's "client is already executing a query"
+  deprecation warning (a hard throw in pg@9). They are now awaited sequentially.
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/journal-pg/package.json
+++ b/packages/journal-pg/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@telia-oss/xjog-journal-pg",
-	"version": "0.3.0",
+	"version": "0.3.1",
 	"description": "XJog Postgres journaling persistence",
 	"engines": {
 		"npm": ">=8.19.4",

--- a/packages/journal-pg/src/PostgresJournalPersistenceAdapter.ts
+++ b/packages/journal-pg/src/PostgresJournalPersistenceAdapter.ts
@@ -181,32 +181,38 @@ export class PostgresJournalPersistenceAdapter extends AbstractPostgresJournalPe
     // Received a notification of a new journal entry. Failures are logged
     // rather than thrown: an exception here would surface as an unhandled
     // rejection inside the notification dispatch and crash the process.
+    //
+    // The two reads are awaited sequentially rather than fired in parallel:
+    // both route through `runReadQuery` on the single shared read connection,
+    // and a `pg.Client` can only execute one query at a time. Overlapping them
+    // triggers pg's "client is already executing a query" deprecation (a hard
+    // throw in pg@9).
     journalSubscriber.notifications.on(channel, async () => {
-      this.queryEntries({
-        afterId: journalEntryIdPointer,
-        updatedAfterAndIncluding: startTime,
-        order: 'DESC',
-      })
-        .then((journalEntries) => {
-          if (journalEntries.length) {
-            yieldJournalEntries(journalEntries);
-          }
-        })
-        .catch((err) =>
-          this.error('Failed to read new journal entries', { err }),
-        );
+      try {
+        const journalEntries = await this.queryEntries({
+          afterId: journalEntryIdPointer,
+          updatedAfterAndIncluding: startTime,
+          order: 'DESC',
+        });
+        if (journalEntries.length) {
+          yieldJournalEntries(journalEntries);
+        }
+      } catch (err) {
+        this.error('Failed to read new journal entries', { err });
+      }
 
-      this.queryFullStates({
-        afterId: fullStateEntryIdPointer,
-        updatedAfterAndIncluding: startTime,
-        order: 'DESC',
-      })
-        .then((fullStateEntries) => {
-          if (fullStateEntries.length) {
-            yieldFullStateEntries(fullStateEntries);
-          }
-        })
-        .catch((err) => this.error('Failed to read new full states', { err }));
+      try {
+        const fullStateEntries = await this.queryFullStates({
+          afterId: fullStateEntryIdPointer,
+          updatedAfterAndIncluding: startTime,
+          order: 'DESC',
+        });
+        if (fullStateEntries.length) {
+          yieldFullStateEntries(fullStateEntries);
+        }
+      } catch (err) {
+        this.error('Failed to read new full states', { err });
+      }
     });
 
     journalSubscriber.events.on('error', (error) => {


### PR DESCRIPTION
## Problem

`PostgresJournalPersistenceAdapter.startObservingNewJournalEntries` fires both `queryEntries` and `queryFullStates` from the pg-listen notification handler without awaiting the first before starting the second:

```js
journalSubscriber.notifications.on(channel, async () => {
  this.queryEntries({ ... }).then(...).catch(...);      // not awaited
  this.queryFullStates({ ... }).then(...).catch(...);   // fires immediately
});
```

Both route through `runReadQuery` → `this.readConnection.query(...)` — the **same** `pg.Client`. A Client can only execute one query at a time, so overlapping them triggers pg's deprecation:

```
DeprecationWarning: Calling client.query() when the client is already executing a query is deprecated and will be removed in pg@9.0.
```

Today pg queues the second query internally so results are correct, but the behavior is deprecated and becomes a hard throw in **pg@9**. It surfaced during a downstream service's dev startup, where the controller churns charts and an early `NOTIFY` lands.

## Fix

Await the two reads sequentially. Each is wrapped in its own try/catch so a failure in one still lets the other run and preserves the existing log-don't-throw semantics (an exception here would surface as an unhandled rejection in the notification dispatch).

Chosen over giving full-state reads a dedicated 5th connection: simpler, and the parallelism gain on two small indexed reads per `NOTIFY` is negligible.

## Testing

Build, biome, and typecheck pass. No regression test added: the handler is private and wired through pg-listen, and because pg queues the overlapping queries internally the observable behavior is identical today (only the warning differs), which makes a deterministic assertion flaky. Flagging rather than shipping a timing-dependent test.
